### PR TITLE
Add Markdown world loader

### DIFF
--- a/engine/world_loader.py
+++ b/engine/world_loader.py
@@ -1,0 +1,108 @@
+"""Load structured world data from Markdown files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import frontmatter
+from markdown_it import MarkdownIt
+from pydantic import BaseModel
+
+
+class SectionEntry(BaseModel):
+    """Generic entry with name and description."""
+
+    name: str
+    description: str
+
+
+class World(BaseModel):
+    """Structured world representation loaded from Markdown."""
+
+    id: str
+    title: str
+    ruleset: str
+    end_goal: str
+    lore: str
+    locations: List[SectionEntry]
+    npcs: List[SectionEntry]
+    factions: List[SectionEntry] = []
+    items: List[SectionEntry] = []
+    rules_notes: str | None = None
+
+
+_md = MarkdownIt()
+
+
+def _slice_section(
+    tokens: list, start_idx: int, level: str, total_lines: int
+) -> tuple[str, int, int]:
+    title = tokens[start_idx + 1].content.strip()
+    start_line = tokens[start_idx].map[1]
+    end_line = total_lines
+    for j in range(start_idx + 1, len(tokens)):
+        t = tokens[j]
+        if t.type == "heading_open" and t.tag == level:
+            end_line = t.map[0]
+            break
+    return title, start_line, end_line
+
+
+def _parse_sections(body: str) -> dict[str, str]:
+    tokens = _md.parse(body)
+    lines = body.splitlines()
+    sections: dict[str, str] = {}
+    for i, token in enumerate(tokens):
+        if token.type == "heading_open" and token.tag == "h2":
+            title, start, end = _slice_section(tokens, i, "h2", len(lines))
+            sections[title] = "\n".join(lines[start:end]).strip()
+    return sections
+
+
+def _parse_entries(text: str) -> List[SectionEntry]:
+    if not text:
+        return []
+    tokens = _md.parse(text)
+    lines = text.splitlines()
+    entries: List[SectionEntry] = []
+    for i, token in enumerate(tokens):
+        if token.type == "heading_open" and token.tag == "h3":
+            name, start, end = _slice_section(tokens, i, "h3", len(lines))
+            description = "\n".join(lines[start:end]).strip()
+            entries.append(SectionEntry(name=name, description=description))
+    return entries
+
+
+def load_world(md_path: str | Path) -> World:
+    """Load a world definition from a Markdown file."""
+
+    post = frontmatter.load(md_path)
+    required = {"id", "title", "ruleset", "end_goal"}
+    if not required.issubset(post.keys()):
+        missing = required.difference(post.keys())
+        raise ValueError(f"Missing frontmatter fields: {', '.join(sorted(missing))}")
+
+    sections = _parse_sections(post.content)
+    return World(
+        id=str(post["id"]),
+        title=str(post["title"]),
+        ruleset=str(post["ruleset"]),
+        end_goal=str(post["end_goal"]),
+        lore=sections.get("Lore", ""),
+        locations=_parse_entries(sections.get("Locations", "")),
+        npcs=_parse_entries(sections.get("NPCs", "")),
+        factions=_parse_entries(sections.get("Factions", "")),
+        items=_parse_entries(sections.get("Items", "")),
+        rules_notes=sections.get("Rules Notes"),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Load and summarize a world file")
+    parser.add_argument("path", help="Path to Markdown world file")
+    args = parser.parse_args()
+    world = load_world(args.path)
+    print(world.model_dump_json(indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "uvicorn",
     "sqlalchemy>=2",
     "pydantic>=2",
+    "python-frontmatter>=1.1.0",
+    "markdown-it-py>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_world_loader.py
+++ b/tests/test_world_loader.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from engine.world_loader import load_world
+
+
+def test_load_world() -> None:
+    world_path = Path(__file__).resolve().parents[1] / "worlds" / "sample_world.md"
+    world = load_world(world_path)
+    assert world.id == "sample"
+    assert world.title == "Sample World"
+    assert world.lore.startswith("A world of test")
+    assert len(world.locations) == 2
+    assert world.locations[0].name == "Town Square"
+    assert any(npc.name == "Dragon" for npc in world.npcs)

--- a/uv.lock
+++ b/uv.lock
@@ -669,6 +669,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload-time = "2024-01-16T18:50:00.911Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.20"
 source = { registry = "https://pypi.org/simple" }
@@ -964,7 +976,9 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
+    { name = "markdown-it-py" },
     { name = "pydantic" },
+    { name = "python-frontmatter" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
 ]
@@ -982,9 +996,11 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
     { name = "fastapi", extras = ["standard"] },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "markdown-it-py", specifier = ">=4.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "uvicorn" },

--- a/worlds/sample_world.md
+++ b/worlds/sample_world.md
@@ -1,0 +1,30 @@
+---
+id: sample
+title: Sample World
+ruleset: dnd5e
+end_goal: Defeat the dragon
+---
+
+## Lore
+A world of test.
+
+## Locations
+### Town Square
+The bustling center.
+
+### Dungeon
+A dark dungeon.
+
+## NPCs
+### Guard
+Watches the square.
+
+### Dragon
+The big bad.
+
+## Items
+### Sword
+A sharp blade.
+
+## Rules Notes
+No magic allowed.


### PR DESCRIPTION
## Summary
- parse Markdown world files with frontmatter into structured models
- provide CLI to output world JSON summaries
- cover loader with tests and sample world data

## Testing
- `pre-commit run --files pyproject.toml engine/world_loader.py tests/test_world_loader.py worlds/sample_world.md`
- `pytest -q`
- `python engine/world_loader.py worlds/sample_world.md`

------
https://chatgpt.com/codex/tasks/task_e_68aad14d6f60832489ee1da73ecad17d