### PR TITLE
Add memory utilities and context prompt builder

### DIFF
--- a/engine/context.py
+++ b/engine/context.py
@@ -1,0 +1,62 @@
+"""Prompt building utilities for the game engine."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .memory import recall
+from .world_loader import SectionEntry, World
+
+
+def _format_entries(entries: List[SectionEntry]) -> str:
+    return ", ".join(entry.name for entry in entries) if entries else "none"
+
+
+def build_prompt(world: World, state: object, k: int = 5) -> str:
+    """Build a textual prompt for the LLM based on the game state.
+
+    Parameters
+    ----------
+    world:
+        The current world definition.
+    state:
+        An object with ``current_location``, ``party``, ``memory`` and
+        ``pending_roll`` attributes.
+    k:
+        Number of memories to include.
+    """
+
+    parts: List[str] = []
+
+    # Location description
+    try:
+        location = world.locations[state.current_location]
+        parts.append(f"Location: {location.name} - {location.description}")
+    except (IndexError, AttributeError):
+        parts.append("Location: unknown")
+
+    # NPCs
+    npcs = _format_entries(world.npcs)
+    parts.append(f"NPCs here: {npcs}")
+
+    # Party roster
+    party_names = ", ".join(
+        member.get("name", "?") for member in getattr(state, "party", [])
+    )
+    parts.append(f"Party: {party_names or 'none'}")
+
+    # Memories
+    memories = getattr(state, "memory", [])
+    top = recall(memories, k)
+    if top:
+        parts.append("Memories: " + "; ".join(m.content for m in top))
+
+    # Rules highlights
+    if world.rules_notes:
+        parts.append(f"Rules: {world.rules_notes}")
+
+    # Pending roll guard
+    if getattr(state, "pending_roll", None):
+        parts.append("Awaiting player roll — do not resolve.")
+
+    return "\n".join(parts)

--- a/engine/memory.py
+++ b/engine/memory.py
@@ -1,0 +1,30 @@
+"""Simple long-term memory system for game state."""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+
+class MemoryItem(BaseModel):
+    """Represents a single memory with an importance score."""
+
+    content: str
+    importance: float = 1.0
+
+
+def remember(memories: List[MemoryItem], content: str, importance: float = 1.0) -> None:
+    """Add a memory to the list."""
+    memories.append(MemoryItem(content=content, importance=importance))
+
+
+def recall(memories: List[MemoryItem], k: int = 5) -> List[MemoryItem]:
+    """Return the top-K memories sorted by importance."""
+    return sorted(memories, key=lambda m: m.importance, reverse=True)[:k]
+
+
+def decay(memories: List[MemoryItem], rate: float = 0.9) -> None:
+    """Decay the importance of all memories by ``rate``."""
+    for memory in memories:
+        memory.importance *= rate

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,26 @@
+"""Tests for memory management utilities."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engine import memory
+
+
+def test_recall_top_k():
+    memories: list[memory.MemoryItem] = []
+    memory.remember(memories, "a", importance=0.1)
+    memory.remember(memories, "b", importance=0.5)
+    memory.remember(memories, "c", importance=0.9)
+
+    top = memory.recall(memories, k=2)
+    assert [m.content for m in top] == ["c", "b"]
+
+
+def test_decay_reduces_importance():
+    memories: list[memory.MemoryItem] = []
+    memory.remember(memories, "event", importance=1.0)
+    memory.decay(memories, rate=0.5)
+    top = memory.recall(memories, k=1)
+    assert top[0].importance == 0.5


### PR DESCRIPTION
## Summary
- implement MemoryItem with remember, recall, and decay helpers
- add context prompt builder to assemble location, party, memories and rule notes
- test memory utilities for top-K recall and decay behavior

## Testing
- `pre-commit run --files engine/memory.py engine/context.py tests/test_memory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad3c10a54832484549fe9392426f9