### PR TITLE
Add rules plug-in interface and implementations

### DIFF
--- a/engine/rules/__init__.py
+++ b/engine/rules/__init__.py
@@ -1,0 +1,7 @@
+"""Rules engine implementations."""
+
+from .base import RuleSystem
+from .dnd5e import DnD5eRules
+from .custom_d6 import CustomD6Rules
+
+__all__ = ["RuleSystem", "DnD5eRules", "CustomD6Rules"]

--- a/engine/rules/base.py
+++ b/engine/rules/base.py
@@ -1,0 +1,47 @@
+"""Base rules interface for game mechanics."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class RuleSystem(ABC):
+    """Abstract base class for rule implementations."""
+
+    @abstractmethod
+    def roll_check(
+        self, bonus: int, dc: int, roll: int | None = None
+    ) -> tuple[bool, int]:
+        """Perform a check for NPCs or monsters.
+
+        Parameters
+        ----------
+        bonus:
+            The modifier to apply to the roll.
+        dc:
+            Difficulty class to beat.
+        roll:
+            Optional predetermined die result for deterministic behaviour.
+
+        Returns
+        -------
+        tuple[bool, int]
+            A tuple of (success, total).
+        """
+
+    @abstractmethod
+    def resolve_player_roll(self, roll: int, bonus: int, dc: int) -> tuple[bool, int]:
+        """Resolve a roll supplied by the player."""
+
+    @abstractmethod
+    def apply_damage(self, hp: int, damage: int) -> int:
+        """Apply damage to hit points and return the new value."""
+
+    @property
+    @abstractmethod
+    def system_instructions(self) -> str:
+        """Instructions describing the rule system for the LLM."""
+
+    @abstractmethod
+    def format_roll_explanation(self, roll: int, bonus: int, dc: int) -> str:
+        """Human readable explanation of a roll."""

--- a/engine/rules/custom_d6.py
+++ b/engine/rules/custom_d6.py
@@ -1,0 +1,42 @@
+"""Simple d6-based rule example."""
+
+from __future__ import annotations
+
+import random
+
+from .base import RuleSystem
+
+
+class CustomD6Rules(RuleSystem):
+    """Light‑weight custom rule system using a single d6."""
+
+    def roll_check(
+        self, bonus: int, dc: int, roll: int | None = None
+    ) -> tuple[bool, int]:
+        roll = roll if roll is not None else random.randint(1, 6)
+        total = roll + bonus
+        if roll == 1:
+            return False, total
+        if roll == 6:
+            return True, total
+        return total >= dc, total
+
+    def resolve_player_roll(self, roll: int, bonus: int, dc: int) -> tuple[bool, int]:
+        total = roll + bonus
+        if roll == 1:
+            return False, total
+        if roll == 6:
+            return True, total
+        return total >= dc, total
+
+    def apply_damage(self, hp: int, damage: int) -> int:
+        return max(hp - damage, 0)
+
+    @property
+    def system_instructions(self) -> str:  # pragma: no cover - static text
+        return "Roll a single d6 for checks. A 6 always succeeds and a 1 always fails."
+
+    def format_roll_explanation(self, roll: int, bonus: int, dc: int) -> str:
+        total = roll + bonus
+        outcome = "success" if (roll == 6 or (roll != 1 and total >= dc)) else "failure"
+        return f"rolled {roll} + {bonus} = {total} vs DC {dc} -> {outcome}"

--- a/engine/rules/dnd5e.py
+++ b/engine/rules/dnd5e.py
@@ -1,0 +1,47 @@
+"""Dungeons & Dragons 5e rule implementation."""
+
+from __future__ import annotations
+
+import random
+
+from .base import RuleSystem
+
+
+class DnD5eRules(RuleSystem):
+    """Basic subset of D&D 5e mechanics."""
+
+    def roll_check(
+        self, bonus: int, dc: int, roll: int | None = None
+    ) -> tuple[bool, int]:
+        roll = roll if roll is not None else random.randint(1, 20)
+        total = roll + bonus
+        if roll == 1:
+            return False, total
+        if roll == 20:
+            return True, total
+        return total >= dc, total
+
+    def resolve_player_roll(self, roll: int, bonus: int, dc: int) -> tuple[bool, int]:
+        total = roll + bonus
+        if roll == 1:
+            return False, total
+        if roll == 20:
+            return True, total
+        return total >= dc, total
+
+    def apply_damage(self, hp: int, damage: int) -> int:
+        return max(hp - damage, 0)
+
+    @property
+    def system_instructions(self) -> str:  # pragma: no cover - static text
+        return (
+            "Use Dungeons & Dragons 5th Edition rules. A 20 always succeeds and a 1 "
+            "always fails."
+        )
+
+    def format_roll_explanation(self, roll: int, bonus: int, dc: int) -> str:
+        total = roll + bonus
+        outcome = (
+            "success" if (roll == 20 or (roll != 1 and total >= dc)) else "failure"
+        )
+        return f"rolled {roll} + {bonus} = {total} vs DC {dc} -> {outcome}"

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,42 @@
+"""Tests for rule system implementations."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engine.rules import CustomD6Rules, DnD5eRules
+
+
+def test_dnd5e_roll_check_success():
+    rules = DnD5eRules()
+    success, total = rules.roll_check(bonus=3, dc=15, roll=12)
+    assert success is True
+    assert total == 15
+
+
+def test_dnd5e_roll_check_natural_edges():
+    rules = DnD5eRules()
+    success, _ = rules.roll_check(bonus=100, dc=1, roll=1)
+    assert success is False
+    success, _ = rules.roll_check(bonus=-5, dc=100, roll=20)
+    assert success is True
+
+
+def test_dnd5e_apply_damage_floor():
+    rules = DnD5eRules()
+    assert rules.apply_damage(hp=5, damage=10) == 0
+
+
+def test_custom_d6_roll_edges():
+    rules = CustomD6Rules()
+    success, _ = rules.roll_check(bonus=0, dc=4, roll=1)
+    assert success is False
+    success, _ = rules.roll_check(bonus=0, dc=10, roll=6)
+    assert success is True
+
+
+def test_format_explanation():
+    rules = DnD5eRules()
+    text = rules.format_roll_explanation(roll=10, bonus=2, dc=15)
+    assert "rolled 10 + 2 = 12 vs DC 15" in text


### PR DESCRIPTION
## Summary
- add abstract `RuleSystem` base for performing checks, resolving player rolls, applying damage, and generating instructions
- implement DnD5e rules with natural 1/20 handling and custom d6 example
- cover rule math and edge cases with unit tests

## Testing
- `pre-commit run --files engine/rules/base.py engine/rules/custom_d6.py engine/rules/__init__.py engine/rules/dnd5e.py tests/test_rules.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad4fe8f90832489bd522fe392e6d9