### PR TITLE
feat: detect DM roll requests

### DIFF
--- a/engine/mechanics.py
+++ b/engine/mechanics.py
@@ -1,0 +1,50 @@
+"""Game mechanics utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class RollRequest(BaseModel):
+    """Data describing a player roll request detected in DM text."""
+
+    skill: str
+    sides: int
+    dc: Optional[int] = None
+
+
+_ROLL_RE = re.compile(
+    r"roll\s+(?:a|an)?\s*d(?P<die>\d+)\s+for\s+"
+    r"(?P<skill>[^()]+)"
+    r"(?:\s*\(dc\s*(?P<dc>\d+)\))?",
+    re.IGNORECASE,
+)
+
+
+def detect_roll_request(dm_text: str) -> Optional[RollRequest]:
+    """Detect a roll request in DM text.
+
+    Parameters
+    ----------
+    dm_text:
+        The narration from the DM.
+
+    Returns
+    -------
+    Optional[RollRequest]
+        Parsed roll request if one is detected, otherwise ``None``.
+    """
+
+    match = _ROLL_RE.search(dm_text)
+    if not match:
+        return None
+
+    sides = int(match.group("die"))
+    skill = match.group("skill").strip().title()
+    dc_str = match.group("dc")
+    dc = int(dc_str) if dc_str is not None else None
+
+    return RollRequest(skill=skill, sides=sides, dc=dc)

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -1,0 +1,22 @@
+"""Tests for roll request detection."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engine import mechanics
+
+
+def test_detects_roll_request():
+    text = "Roll a d20 for Perception (DC 15)"
+    req = mechanics.detect_roll_request(text)
+    assert req is not None
+    assert req.sides == 20
+    assert req.skill == "Perception"
+    assert req.dc == 15
+
+
+def test_no_roll_request():
+    text = "The dragon snarls and watches you carefully."
+    assert mechanics.detect_roll_request(text) is None


### PR DESCRIPTION
## Summary
- detect roll requests in DM text
- test roll request detection logic

## Testing
- `pre-commit run --files engine/mechanics.py tests/test_mechanics.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad88b553c8324863b8aa905c2607a