### PR TITLE
feat: handle player roll submissions

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI, HTTPException
 import httpx
+from pydantic import BaseModel
 
+from .engine_service import DMResponse, submit_player_roll
 from .llm.ollama_client import list_models
 
 app = FastAPI()
@@ -18,3 +20,19 @@ async def llm_health() -> dict[str, list[str]]:
     except httpx.HTTPError as exc:
         raise HTTPException(status_code=503, detail="Ollama unavailable") from exc
     return {"models": models}
+
+
+class PlayerRoll(BaseModel):
+    request_id: str
+    value: int
+    mod: int = 0
+
+
+@app.post("/games/{game_id}/player-roll")
+async def player_roll(game_id: int, roll: PlayerRoll) -> DMResponse:
+    try:
+        return await submit_player_roll(game_id, roll.request_id, roll.value, roll.mod)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/test_player_roll_submission.py
+++ b/tests/test_player_roll_submission.py
@@ -1,0 +1,55 @@
+"""Integration test for player roll submission endpoint."""
+
+from pathlib import Path
+import sys
+import asyncio
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from server.app import engine_service
+from server.app.main import app
+from engine.world_loader import World, SectionEntry
+
+
+def test_player_roll_submission(monkeypatch):
+    responses = [
+        "You look around. Roll a d20 for Perception (DC 10).",
+        "You spot a hidden door.",
+    ]
+
+    async def fake_generate(*, model, prompt):
+        return responses.pop(0)
+
+    monkeypatch.setattr(engine_service, "generate", fake_generate)
+
+    world = World(
+        id="w1",
+        title="World",
+        ruleset="dnd5e",
+        end_goal="",
+        lore="",
+        locations=[SectionEntry(name="Start", description="")],
+        npcs=[],
+    )
+    engine_service._WORLDS[1] = world
+    engine_service._GAME_STATES[1] = engine_service.GameState(
+        world_id=1, current_location=0
+    )
+
+    asyncio.run(engine_service.run_turn(1, "look"))
+
+    pending = engine_service._GAME_STATES[1].pending_roll
+    assert pending is not None
+
+    client = TestClient(app)
+    resp = client.post(
+        "/games/1/player-roll",
+        json={"request_id": pending["id"], "value": 15, "mod": 0},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["awaiting_player_roll"] is False
+    assert data["message"] == "You spot a hidden door."
+    assert engine_service._GAME_STATES[1].pending_roll is None


### PR DESCRIPTION
## Summary
- track roll requests with IDs and resolve player dice rolls
- expose POST /games/{id}/player-roll endpoint
- cover E2E roll submission flow with tests

## Testing
- `pre-commit run --files server/app/main.py server/app/engine_service.py tests/test_player_roll_submission.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad9f83ea4832492f4bc45cab2a7ce