### PR TITLE
Add party system with companions and pets

### DIFF
--- a/engine/context.py
+++ b/engine/context.py
@@ -39,11 +39,16 @@ def build_prompt(world: World, state: object, k: int = 5) -> str:
     npcs = _format_entries(world.npcs)
     parts.append(f"NPCs here: {npcs}")
 
-    # Party roster
-    party_names = ", ".join(
-        member.get("name", "?") for member in getattr(state, "party", [])
-    )
-    parts.append(f"Party: {party_names or 'none'}")
+    # Party roster with personas
+    roster = []
+    for member in getattr(state, "party", []):
+        name = member.get("name", "?")
+        persona = member.get("persona")
+        if persona:
+            roster.append(f"{name}: {persona}")
+        else:
+            roster.append(name)
+    parts.append(f"Party: {', '.join(roster) or 'none'}")
 
     # Memories
     memories = getattr(state, "memory", [])

--- a/engine/models.py
+++ b/engine/models.py
@@ -80,6 +80,7 @@ class Character(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
+    persona: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     stats: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
     type: Mapped[str] = mapped_column(String(50), default="character")
 
@@ -122,3 +123,21 @@ class GameState(Base):
     timeline: Mapped[List[str]] = mapped_column(JSON, default=list)
     memory: Mapped[List[str]] = mapped_column(JSON, default=list)
     pending_roll: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, nullable=True)
+
+    def add_companion(self, companion: Dict[str, Any]) -> None:
+        """Add a companion to the party enforcing a limit of three."""
+
+        companions = [m for m in self.party if m.get("type") == "companion"]
+        if len(companions) >= 3:
+            raise ValueError("party already has maximum companions")
+        data = {"type": "companion", **companion}
+        self.party.append(data)
+
+    def add_pet(self, pet: Dict[str, Any]) -> None:
+        """Add a pet to the party enforcing a limit of two."""
+
+        pets = [m for m in self.party if m.get("type") == "pet"]
+        if len(pets) >= 2:
+            raise ValueError("party already has maximum pets")
+        data = {"type": "pet", **pet}
+        self.party.append(data)

--- a/server/app/engine_service.py
+++ b/server/app/engine_service.py
@@ -33,6 +33,24 @@ class GameState:
     memory: list[MemoryItem] = field(default_factory=list)
     pending_roll: Dict[str, Any] | None = None
 
+    def add_companion(self, companion: dict[str, Any]) -> None:
+        """Add a companion to the party enforcing a maximum of three."""
+
+        companions = [m for m in self.party if m.get("type") == "companion"]
+        if len(companions) >= 3:
+            raise ValueError("party already has maximum companions")
+        data = {"type": "companion", **companion}
+        self.party.append(data)
+
+    def add_pet(self, pet: dict[str, Any]) -> None:
+        """Add a pet to the party enforcing a maximum of two."""
+
+        pets = [m for m in self.party if m.get("type") == "pet"]
+        if len(pets) >= 2:
+            raise ValueError("party already has maximum pets")
+        data = {"type": "pet", **pet}
+        self.party.append(data)
+
 
 @dataclass
 class DMResponse:
@@ -46,7 +64,8 @@ class DMResponse:
 SYSTEM_INSTRUCTIONS = (
     "You are a fair and impartial DM. "
     "Describe the world and the results of actions, "
-    "but never roll for the player."
+    "but never roll for the player. "
+    "Resolve companion and pet actions internally without requesting player rolls."
 )
 
 

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -59,6 +59,7 @@ class Character(BaseModel):
     id: int | None = None
     name: str
     stats: Stats
+    persona: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engine import models, context
+from engine.world_loader import World, SectionEntry
+
+
+def _make_world() -> World:
+    return World(
+        id="w",
+        title="World",
+        ruleset="dnd5e",
+        end_goal="",
+        lore="",
+        locations=[SectionEntry(name="Town", description="")],
+        npcs=[],
+        factions=[],
+        items=[],
+        rules_notes=None,
+    )
+
+
+def test_party_limits_and_prompt_personas() -> None:
+    state = models.GameState(
+        world_id=1,
+        current_location=0,
+        party=[],
+        flags={},
+        timeline=[],
+        memory=[],
+        pending_roll=None,
+    )
+
+    # Add companions up to limit
+    for i in range(3):
+        state.add_companion({"id": i, "name": f"C{i}", "persona": f"P{i}"})
+    with pytest.raises(ValueError):
+        state.add_companion({"id": 4, "name": "C4", "persona": "P4"})
+
+    # Add pets up to limit
+    for i in range(2):
+        state.add_pet({"id": i, "name": f"Pet{i}", "persona": f"PP{i}"})
+    with pytest.raises(ValueError):
+        state.add_pet({"id": 3, "name": "Pet3", "persona": "PP3"})
+
+    world = _make_world()
+    prompt = context.build_prompt(world, state)
+    assert "C0: P0" in prompt and "Pet0: PP0" in prompt


### PR DESCRIPTION
## Summary
- allow characters to store optional persona text
- add helper methods to add companions and pets with party size limits and persona injection
- include companion and pet personas in prompts and DM instructions
- add tests for party limits and persona prompting

## Testing
- `pre-commit run --files engine/models.py engine/context.py server/schemas.py server/app/engine_service.py tests/test_party.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aade6bd40c832491b1db1d88057a98