### PR TITLE
feat: add save/load endpoints and world export

### DIFF
--- a/engine/world_loader.py
+++ b/engine/world_loader.py
@@ -98,6 +98,47 @@ def load_world(md_path: str | Path) -> World:
     )
 
 
+def dump_world(world: World) -> str:
+    """Serialise a :class:`World` back into Markdown format."""
+
+    lines: list[str] = [
+        "---",
+        f"id: {world.id}",
+        f"title: {world.title}",
+        f"ruleset: {world.ruleset}",
+        f"end_goal: {world.end_goal}",
+        "---",
+        "",
+        "## Lore",
+        world.lore,
+    ]
+
+    if world.locations:
+        lines.append("\n## Locations")
+        for entry in world.locations:
+            lines.extend([f"\n### {entry.name}", entry.description])
+
+    if world.npcs:
+        lines.append("\n## NPCs")
+        for entry in world.npcs:
+            lines.extend([f"\n### {entry.name}", entry.description])
+
+    if world.factions:
+        lines.append("\n## Factions")
+        for entry in world.factions:
+            lines.extend([f"\n### {entry.name}", entry.description])
+
+    if world.items:
+        lines.append("\n## Items")
+        for entry in world.items:
+            lines.extend([f"\n### {entry.name}", entry.description])
+
+    if world.rules_notes:
+        lines.extend(["\n## Rules Notes", world.rules_notes])
+
+    return "\n".join(lines) + "\n"
+
+
 if __name__ == "__main__":  # pragma: no cover
     import argparse
 

--- a/server/app/engine_service.py
+++ b/server/app/engine_service.py
@@ -52,6 +52,42 @@ class GameState:
         self.party.append(data)
 
 
+def export_game_state(game_id: int) -> Dict[str, Any]:
+    """Return a serialisable representation of a game state."""
+
+    state = _GAME_STATES.get(game_id)
+    if state is None:
+        raise KeyError(f"Unknown game id: {game_id}")
+    return {
+        "id": game_id,
+        "world_id": state.world_id,
+        "current_location": state.current_location,
+        "party": state.party,
+        "flags": state.flags,
+        "timeline": state.timeline,
+        "memory": [m.model_dump() for m in state.memory],
+        "pending_roll": state.pending_roll,
+    }
+
+
+def import_game_state(data: Dict[str, Any]) -> int:
+    """Create a new game from a previously exported state."""
+
+    memory = [MemoryItem(**m) for m in data.get("memory", [])]
+    state = GameState(
+        world_id=int(data["world_id"]),
+        current_location=int(data.get("current_location", 0)),
+        party=list(data.get("party", [])),
+        flags=dict(data.get("flags", {})),
+        timeline=list(data.get("timeline", [])),
+        memory=memory,
+        pending_roll=data.get("pending_roll"),
+    )
+    new_id = max(_GAME_STATES.keys(), default=0) + 1
+    _GAME_STATES[new_id] = state
+    return new_id
+
+
 @dataclass
 class DMResponse:
     """Response returned after processing a turn."""

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,9 +1,18 @@
-from fastapi import FastAPI, HTTPException
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException, Response
 import httpx
 from pydantic import BaseModel
 
-from .engine_service import DMResponse, submit_player_roll
+from .engine_service import (
+    DMResponse,
+    _WORLDS,
+    export_game_state,
+    import_game_state,
+    submit_player_roll,
+)
 from .llm.ollama_client import list_models
+from engine.world_loader import dump_world
 
 app = FastAPI()
 
@@ -36,3 +45,29 @@ async def player_roll(game_id: int, roll: PlayerRoll) -> DMResponse:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/games/{game_id}/save")
+def save_game(game_id: int) -> Dict[str, Any]:
+    try:
+        return export_game_state(game_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+class GameImport(BaseModel):
+    state: Dict[str, Any]
+
+
+@app.post("/games/import")
+def import_game(payload: GameImport) -> Dict[str, int]:
+    new_id = import_game_state(payload.state)
+    return {"id": new_id}
+
+
+@app.get("/worlds/{world_id}/export")
+def export_world(world_id: int) -> Response:
+    world = _WORLDS.get(world_id)
+    if world is None:
+        raise HTTPException(status_code=404, detail="Unknown world")
+    return Response(content=dump_world(world), media_type="text/markdown")

--- a/tests/test_save_load_export.py
+++ b/tests/test_save_load_export.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from server.app import engine_service
+from server.app.main import app
+from engine.world_loader import World, SectionEntry, load_world
+
+
+def test_save_export_import_flow(tmp_path, monkeypatch):
+    """Game state can be saved, exported, imported and resumed."""
+
+    # Prepare a simple world and game state
+    world = World(
+        id="w1",
+        title="World",
+        ruleset="dnd5e",
+        end_goal="",
+        lore="lore",
+        locations=[SectionEntry(name="Start", description="desc")],
+        npcs=[],
+    )
+    engine_service._WORLDS[1] = world
+    state = engine_service.GameState(world_id=1, current_location=0)
+    state.pending_roll = {"id": "abc", "dc": 10}
+    engine_service._GAME_STATES[1] = state
+
+    client = TestClient(app)
+
+    # Save the game
+    resp = client.get("/games/1/save")
+    assert resp.status_code == 200
+    saved = resp.json()
+    assert saved["pending_roll"]["dc"] == 10
+
+    # Export the world
+    resp_w = client.get("/worlds/1/export")
+    assert resp_w.status_code == 200
+    md_text = resp_w.text
+    assert "id: w1" in md_text
+
+    # Wipe in-memory storage
+    engine_service._GAME_STATES.clear()
+    engine_service._WORLDS.clear()
+
+    # Re-import world from exported markdown
+    path = tmp_path / "world.md"
+    path.write_text(md_text)
+    engine_service._WORLDS[1] = load_world(path)
+
+    # Import game state
+    resp_import = client.post("/games/import", json={"state": saved})
+    assert resp_import.status_code == 200
+    new_id = resp_import.json()["id"]
+    assert new_id == 1
+    assert engine_service._GAME_STATES[new_id].pending_roll == saved["pending_roll"]
+
+    # Resume play
+    async def fake_generate(*, model, prompt):
+        return "Resumed."
+
+    monkeypatch.setattr(engine_service, "generate", fake_generate)
+    result = asyncio.run(engine_service.run_turn(new_id, "hello"))
+    assert result.message == "Resumed."
+    assert engine_service._GAME_STATES[new_id].pending_roll is None


### PR DESCRIPTION
## Summary
- serialize game state with pending rolls and restore from JSON
- export world definitions back to markdown
- expose `/games/{id}/save`, `/games/import`, and `/worlds/{id}/export` API endpoints
- test save/export/import resume flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aae041888c83248d98de7a9633b6f0