### PR TITLE
feat: expose public API surface for worlds and games

### DIFF
--- a/engine/world_loader.py
+++ b/engine/world_loader.py
@@ -74,10 +74,9 @@ def _parse_entries(text: str) -> List[SectionEntry]:
     return entries
 
 
-def load_world(md_path: str | Path) -> World:
-    """Load a world definition from a Markdown file."""
+def _build_world(post: frontmatter.Post) -> World:
+    """Construct a :class:`World` instance from frontmatter ``Post`` data."""
 
-    post = frontmatter.load(md_path)
     required = {"id", "title", "ruleset", "end_goal"}
     if not required.issubset(post.keys()):
         missing = required.difference(post.keys())
@@ -96,6 +95,20 @@ def load_world(md_path: str | Path) -> World:
         items=_parse_entries(sections.get("Items", "")),
         rules_notes=sections.get("Rules Notes"),
     )
+
+
+def load_world(md_path: str | Path) -> World:
+    """Load a world definition from a Markdown file."""
+
+    post = frontmatter.load(md_path)
+    return _build_world(post)
+
+
+def load_world_from_string(text: str) -> World:
+    """Load a world definition from a Markdown string."""
+
+    post = frontmatter.loads(text)
+    return _build_world(post)
 
 
 def dump_world(world: World) -> str:

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,14 +1,20 @@
-from typing import Any, Dict
-
 from fastapi import FastAPI, HTTPException, Response
 import httpx
 from pydantic import BaseModel
+from typing import Any, Dict
 
 from .engine_service import (
     DMResponse,
-    _WORLDS,
+    add_companion,
+    create_game,
     export_game_state,
+    get_game_state,
+    get_world,
     import_game_state,
+    import_world,
+    list_worlds,
+    remove_companion,
+    run_turn,
     submit_player_roll,
 )
 from .llm.ollama_client import list_models
@@ -31,10 +37,70 @@ async def llm_health() -> dict[str, list[str]]:
     return {"models": models}
 
 
+@app.get("/worlds")
+def worlds() -> list[dict[str, Any]]:
+    """List all available worlds."""
+
+    return list_worlds()
+
+
+class WorldImport(BaseModel):
+    content: str
+
+
+@app.post("/worlds/import")
+def import_world_endpoint(payload: WorldImport) -> dict[str, int]:
+    new_id = import_world(payload.content)
+    return {"id": new_id}
+
+
+@app.get("/worlds/{world_id}")
+def get_world_endpoint(world_id: int) -> Dict[str, Any]:
+    try:
+        world = get_world(world_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return world.model_dump()
+
+
 class PlayerRoll(BaseModel):
     request_id: str
     value: int
     mod: int = 0
+
+
+class GameCreate(BaseModel):
+    world_id: int
+
+
+@app.post("/games")
+def create_game_endpoint(payload: GameCreate) -> dict[str, int]:
+    try:
+        new_id = create_game(payload.world_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"id": new_id}
+
+
+@app.get("/games/{game_id}")
+def get_game_endpoint(game_id: int) -> Dict[str, Any]:
+    try:
+        return get_game_state(game_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+class TurnRequest(BaseModel):
+    message: str
+    model: str = "llama3"
+
+
+@app.post("/games/{game_id}/turn")
+async def game_turn(game_id: int, payload: TurnRequest) -> DMResponse:
+    try:
+        return await run_turn(game_id, payload.message, model=payload.model)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @app.post("/games/{game_id}/player-roll")
@@ -45,6 +111,32 @@ async def player_roll(game_id: int, roll: PlayerRoll) -> DMResponse:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+class CompanionPayload(BaseModel):
+    id: int
+    name: str
+    persona: str
+
+
+@app.post("/games/{game_id}/companions")
+def add_companion_endpoint(game_id: int, companion: CompanionPayload) -> dict[str, str]:
+    try:
+        add_companion(game_id, companion.model_dump())
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"status": "ok"}
+
+
+@app.delete("/games/{game_id}/companions/{companion_id}")
+def remove_companion_endpoint(game_id: int, companion_id: int) -> dict[str, str]:
+    try:
+        remove_companion(game_id, companion_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"status": "ok"}
 
 
 @app.get("/games/{game_id}/save")
@@ -67,7 +159,8 @@ def import_game(payload: GameImport) -> Dict[str, int]:
 
 @app.get("/worlds/{world_id}/export")
 def export_world(world_id: int) -> Response:
-    world = _WORLDS.get(world_id)
-    if world is None:
-        raise HTTPException(status_code=404, detail="Unknown world")
+    try:
+        world = get_world(world_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return Response(content=dump_world(world), media_type="text/markdown")

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.app.main import app
+
+
+def test_openapi_has_public_routes():
+    client = TestClient(app)
+    paths = client.get("/openapi.json").json()["paths"]
+    expected = [
+        "/worlds",
+        "/worlds/{world_id}",
+        "/worlds/import",
+        "/worlds/{world_id}/export",
+        "/games",
+        "/games/{game_id}",
+        "/games/{game_id}/turn",
+        "/games/{game_id}/player-roll",
+        "/games/{game_id}/companions",
+        "/games/{game_id}/companions/{companion_id}",
+        "/games/{game_id}/save",
+        "/games/import",
+        "/health",
+        "/health/llm",
+    ]
+    for path in expected:
+        assert path in paths


### PR DESCRIPTION
## Summary
- add string loader for world markdown
- implement world and game management helpers in engine service
- expose FastAPI endpoints for listing/importing worlds, game lifecycle, turns, and companions
- document routes through openapi test

## Testing
- `pre-commit run --files engine/world_loader.py server/app/engine_service.py server/app/main.py tests/test_api_surface.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aae150c6e8832488fa9e8ccc6b8842