### PR TITLE
feat(web): add streaming chat component

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "react-virtuoso": "^4.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-router-dom:
         specifier: ^7.8.2
         version: 7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react-virtuoso:
+        specifier: ^4.14.0
+        version: 4.14.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.33.0
@@ -1265,6 +1268,12 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-virtuoso@4.14.0:
+    resolution: {integrity: sha512-fR+eiCvirSNIRvvCD7ueJPRsacGQvUbjkwgWzBZXVq+yWypoH7mRUvWJzGHIdoRaCZCT+6mMMMwIG2S1BW3uwA==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
@@ -2629,6 +2638,11 @@ snapshots:
       react: 19.1.1
       set-cookie-parser: 2.7.1
     optionalDependencies:
+      react-dom: 19.1.1(react@19.1.1)
+
+  react-virtuoso@4.14.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
   react@19.1.1: {}

--- a/web/src/components/ChatStream.tsx
+++ b/web/src/components/ChatStream.tsx
@@ -1,0 +1,30 @@
+import { Virtuoso } from 'react-virtuoso'
+
+export type ChatMessage = {
+  id: string
+  role: 'player' | 'dm'
+  content: string
+}
+
+interface Props {
+  messages: ChatMessage[]
+}
+
+export default function ChatStream({ messages }: Props) {
+  return (
+    <Virtuoso
+      data={messages}
+      followOutput="smooth"
+      className="flex-1 overflow-y-auto p-4"
+      itemContent={(_, msg) => (
+        <div
+          className={`mb-2 whitespace-pre-wrap ${
+            msg.role === 'player' ? 'text-blue-300' : 'text-gray-100'
+          }`}
+        >
+          {msg.content}
+        </div>
+      )}
+    />
+  )
+}

--- a/web/src/components/InputBar.tsx
+++ b/web/src/components/InputBar.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+
+interface Props {
+  onSend: (text: string) => void
+  onCommand: (cmd: string) => void
+}
+
+export default function InputBar({ onSend, onCommand }: Props) {
+  const [value, setValue] = useState('')
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = value.trim()
+    if (!trimmed) return
+    if (trimmed.startsWith('/')) {
+      onCommand(trimmed.slice(1))
+    } else {
+      onSend(trimmed)
+    }
+    setValue('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border-t border-gray-700 p-4">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Type your action... (/save, /party, /help)"
+        className="w-full rounded border border-gray-700 bg-gray-800 p-2"
+      />
+    </form>
+  )
+}

--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -1,19 +1,76 @@
 import { useParams } from 'react-router-dom'
+import { useState } from 'react'
+import ChatStream, { ChatMessage } from '../components/ChatStream'
+import InputBar from '../components/InputBar'
 
 export default function PlayPage() {
   const { gameId } = useParams()
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+
+  async function sendAction(text: string) {
+    const playerMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'player',
+      content: text,
+    }
+    const dmMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'dm',
+      content: '',
+    }
+    setMessages((prev) => [...prev, playerMsg, dmMsg])
+
+    try {
+      const resp = await fetch(`/games/${gameId}/turn`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text }),
+      })
+      const reader = resp.body?.getReader()
+      const decoder = new TextDecoder()
+      if (!reader) return
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === dmMsg.id
+              ? { ...m, content: m.content + decoder.decode(value) }
+              : m,
+          ),
+        )
+      }
+    } catch {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === dmMsg.id ? { ...m, content: '[error streaming]' } : m,
+        ),
+      )
+    }
+  }
+
+  function handleCommand(cmd: string) {
+    switch (cmd) {
+      case 'save':
+        console.log('save game')
+        break
+      case 'party':
+        console.log('show party')
+        break
+      case 'help':
+        console.log('show help')
+        break
+      default:
+        console.log('unknown command', cmd)
+    }
+  }
+
   return (
     <div className="flex h-full flex-col md:flex-row dark:bg-gray-900 dark:text-gray-100">
       <aside className="hidden w-64 border-r border-gray-700 p-4 md:block">Left Panel</aside>
       <main className="flex flex-1 flex-col">
-        <div className="flex-1 overflow-y-auto p-4">Story for game {gameId}</div>
-        <div className="border-t border-gray-700 p-4">
-          <input
-            type="text"
-            placeholder="Type your action..."
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2"
-          />
-        </div>
+        <ChatStream messages={messages} />
+        <InputBar onSend={sendAction} onCommand={handleCommand} />
       </main>
       <aside className="hidden w-64 border-l border-gray-700 p-4 md:block">Right Panel</aside>
     </div>


### PR DESCRIPTION
## Summary
- add ChatStream component with virtualization and autoscroll
- add InputBar with slash commands
- wire streaming turn handling in PlayPage

## Testing
- `pnpm --dir web lint`
- `pnpm --dir web typecheck`
- `pre-commit run --files web/package.json web/pnpm-lock.yaml web/src/pages/PlayPage.tsx web/src/components/ChatStream.tsx web/src/components/InputBar.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aae9aa2d9083249abc5b597f33bd47