### PR TITLE
feat(web): add player roll UI

### DIFF
--- a/web/src/components/InputBar.tsx
+++ b/web/src/components/InputBar.tsx
@@ -3,9 +3,10 @@ import { useState } from 'react'
 interface Props {
   onSend: (text: string) => void
   onCommand: (cmd: string) => void
+  disabled?: boolean
 }
 
-export default function InputBar({ onSend, onCommand }: Props) {
+export default function InputBar({ onSend, onCommand, disabled = false }: Props) {
   const [value, setValue] = useState('')
 
   function handleSubmit(e: React.FormEvent) {
@@ -28,6 +29,7 @@ export default function InputBar({ onSend, onCommand }: Props) {
         onChange={(e) => setValue(e.target.value)}
         placeholder="Type your action... (/save, /party, /help)"
         className="w-full rounded border border-gray-700 bg-gray-800 p-2"
+        disabled={disabled}
       />
     </form>
   )

--- a/web/src/components/RollPrompt.tsx
+++ b/web/src/components/RollPrompt.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+
+export interface RollRequest {
+  id: string
+  skill: string
+  sides: number
+  dc?: number | null
+}
+
+interface Props {
+  request: RollRequest
+  onSubmit: (value: number, mod: number) => Promise<void> | void
+}
+
+export default function RollPrompt({ request, onSubmit }: Props) {
+  const [value, setValue] = useState('')
+  const [mod, setMod] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const rollValue = parseInt(value, 10)
+    if (isNaN(rollValue) || rollValue < 1 || rollValue > request.sides) {
+      setError(`Enter a number between 1 and ${request.sides}`)
+      return
+    }
+    try {
+      await onSubmit(rollValue, mod)
+      setValue('')
+      setMod(0)
+      setError(null)
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  return (
+    <div className="border-b border-yellow-600 bg-yellow-800 p-4 text-yellow-100">
+      <div className="mb-2 font-semibold">
+        Roll a d{request.sides} for {request.skill}
+        {request.dc !== undefined && request.dc !== null && ` (DC ${request.dc})`}
+      </div>
+      <form onSubmit={handleSubmit} className="flex items-center gap-2">
+        <input
+          type="number"
+          min={1}
+          max={request.sides}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="w-20 rounded p-1 text-gray-900"
+        />
+        <span>+</span>
+        <input
+          type="number"
+          value={mod}
+          onChange={(e) => setMod(Number(e.target.value))}
+          className="w-16 rounded p-1 text-gray-900"
+        />
+        <button type="submit" className="rounded bg-yellow-600 px-3 py-1 text-gray-900">
+          Submit
+        </button>
+      </form>
+      {error && <div className="mt-2 text-red-200">{error}</div>}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- disable chat input when waiting for a player roll
- add RollPrompt banner for dice requests and roll submission
- wire PlayPage to submit roll results and resume narration

## Testing
- `pre-commit run --files web/src/components/InputBar.tsx web/src/pages/PlayPage.tsx web/src/components/RollPrompt.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaedc9bc848324b08d7095eb430d32