### PR TITLE
Add in-app world editor with Markdown validation

### DIFF
--- a/server/app/engine_service.py
+++ b/server/app/engine_service.py
@@ -70,6 +70,12 @@ def import_world(markdown: str) -> int:
     return new_id
 
 
+def validate_world(markdown: str) -> World:
+    """Parse a world definition without persisting it."""
+
+    return load_world_from_string(markdown)
+
+
 def get_world(world_id: int) -> World:
     """Retrieve a world by identifier."""
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -12,6 +12,7 @@ from .engine_service import (
     get_world,
     import_game_state,
     import_world,
+    validate_world,
     list_worlds,
     remove_companion,
     run_turn,
@@ -52,6 +53,15 @@ class WorldImport(BaseModel):
 def import_world_endpoint(payload: WorldImport) -> dict[str, int]:
     new_id = import_world(payload.content)
     return {"id": new_id}
+
+
+@app.post("/worlds/validate")
+def validate_world_endpoint(payload: WorldImport) -> Dict[str, Any]:
+    try:
+        world = validate_world(payload.content)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return world.model_dump()
 
 
 @app.get("/worlds/{world_id}")

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import './index.css'
 import HomePage from './pages/HomePage.tsx'
 import PlayPage from './pages/PlayPage.tsx'
 import WorldsPage from './pages/WorldsPage.tsx'
+import WorldEditorPage from './pages/WorldEditorPage.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -14,6 +15,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/" element={<HomePage />} />
         <Route path="/play/:gameId" element={<PlayPage />} />
         <Route path="/worlds" element={<WorldsPage />} />
+        <Route path="/worlds/new" element={<WorldEditorPage />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/web/src/pages/WorldEditorPage.tsx
+++ b/web/src/pages/WorldEditorPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
+
+interface ParsedWorld {
+  id: string
+  title: string
+  ruleset: string
+  end_goal: string
+  lore: string
+  locations: unknown[]
+  npcs: unknown[]
+  factions: unknown[]
+  items: unknown[]
+  rules_notes?: string | null
+}
+
+export default function WorldEditorPage() {
+  const navigate = useNavigate()
+  const [markdown, setMarkdown] = useState(
+    `---\nid: demo\ntitle: Demo World\nruleset: custom_d6\nend_goal: Have fun\n---\n\n## Lore\nDescribe your world.\n`
+  )
+  const [preview, setPreview] = useState<ParsedWorld | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`${API_BASE}/worlds/validate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: markdown }),
+          signal: controller.signal,
+        })
+        if (!res.ok) {
+          const data = await res.json()
+          throw new Error(data.detail ?? 'invalid markdown')
+        }
+        const data = await res.json()
+        setPreview(data)
+        setError(null)
+      } catch (err) {
+        setPreview(null)
+        setError((err as Error).message)
+      }
+    }, 300)
+    return () => {
+      controller.abort()
+      clearTimeout(timer)
+    }
+  }, [markdown])
+
+  async function handleSave() {
+    const res = await fetch(`${API_BASE}/worlds/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: markdown }),
+    })
+    if (!res.ok) return
+    const { id: worldId } = await res.json()
+    const res2 = await fetch(`${API_BASE}/games`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ world_id: worldId }),
+    })
+    if (!res2.ok) return
+    const { id: gameId } = await res2.json()
+    navigate(`/play/${gameId}`)
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-gray-100 dark:bg-gray-900 dark:text-gray-100">
+      <div className="flex flex-1 flex-col md:flex-row">
+        <textarea
+          value={markdown}
+          onChange={(e) => setMarkdown(e.target.value)}
+          className="h-64 flex-1 border border-gray-700 bg-white p-2 font-mono dark:bg-gray-800 md:h-auto"
+        />
+        <div className="flex-1 overflow-auto border border-gray-700 p-2">
+          {error && <p className="text-red-500">{error}</p>}
+          {preview && <pre className="text-xs">{JSON.stringify(preview, null, 2)}</pre>}
+        </div>
+      </div>
+      <div className="border-t border-gray-700 p-2 text-right">
+        <button
+          onClick={handleSave}
+          className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+        >
+          Save &amp; Play
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/WorldsPage.tsx
+++ b/web/src/pages/WorldsPage.tsx
@@ -1,9 +1,40 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
+
+interface WorldSummary {
+  id: number
+  title: string
+  ruleset: string
+}
+
 export default function WorldsPage() {
+  const [worlds, setWorlds] = useState<WorldSummary[]>([])
+
+  useEffect(() => {
+    fetch(`${API_BASE}/worlds`)
+      .then((r) => r.json())
+      .then((data) => setWorlds(data as WorldSummary[]))
+      .catch(() => setWorlds([]))
+  }, [])
+
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-4 bg-gray-100 p-4 dark:bg-gray-900 dark:text-gray-100">
+    <div className="flex h-full flex-col items-center gap-4 bg-gray-100 p-4 dark:bg-gray-900 dark:text-gray-100">
       <h1 className="text-2xl font-bold">Worlds</h1>
+      <ul className="w-full max-w-md flex-1 overflow-auto">
+        {worlds.map((w) => (
+          <li key={w.id} className="border-b border-gray-700 p-2">
+            {w.title} <span className="text-sm text-gray-500">({w.ruleset})</span>
+          </li>
+        ))}
+      </ul>
+      <Link
+        to="/worlds/new"
+        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+      >
+        New World
+      </Link>
       <Link to="/" className="text-blue-500 underline">
         Back
       </Link>


### PR DESCRIPTION
## Summary
- add backend endpoint to validate Markdown world files
- introduce split-pane world editor UI with live preview and save-to-play flow
- list existing worlds and link to editor

## Testing
- `pre-commit run --files server/app/engine_service.py server/app/main.py web/src/main.tsx web/src/pages/WorldEditorPage.tsx web/src/pages/WorldsPage.tsx`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaefe4619483249e63fe528f652f5e