### PR TITLE
feat: switchable rulesets with UI indicator

### DIFF
--- a/engine/rules/__init__.py
+++ b/engine/rules/__init__.py
@@ -4,4 +4,35 @@ from .base import RuleSystem
 from .dnd5e import DnD5eRules
 from .custom_d6 import CustomD6Rules
 
-__all__ = ["RuleSystem", "DnD5eRules", "CustomD6Rules"]
+_RULESET_MAP = {
+    "dnd5e": DnD5eRules,
+    "custom_d6": CustomD6Rules,
+}
+
+
+def get_ruleset(name: str) -> RuleSystem:
+    """Return an instance of the ruleset ``name``.
+
+    Parameters
+    ----------
+    name:
+        Identifier of the ruleset such as ``"dnd5e"`` or ``"custom_d6"``.
+
+    Returns
+    -------
+    RuleSystem
+        Instantiated rules engine implementation.
+    """
+
+    cls = _RULESET_MAP.get(name.lower())
+    if cls is None:
+        raise ValueError(f"Unknown ruleset: {name}")
+    return cls()
+
+
+__all__ = [
+    "RuleSystem",
+    "DnD5eRules",
+    "CustomD6Rules",
+    "get_ruleset",
+]

--- a/tests/test_rule_switching.py
+++ b/tests/test_rule_switching.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.app import engine_service
+from engine.world_loader import World
+
+
+def _make_world(idx: int, ruleset: str) -> None:
+    world = World(
+        id=f"w{idx}",
+        title="World",
+        ruleset=ruleset,
+        end_goal="",
+        lore="",
+        locations=[],
+        npcs=[],
+    )
+    engine_service._WORLDS[idx] = world
+
+
+def test_submit_roll_uses_world_rules(monkeypatch):
+    _make_world(1, "dnd5e")
+    _make_world(2, "custom_d6")
+    game_dnd = engine_service.create_game(1)
+    game_d6 = engine_service.create_game(2)
+    engine_service._GAME_STATES[game_dnd].pending_roll = {"id": "a", "dc": 10}
+    engine_service._GAME_STATES[game_d6].pending_roll = {"id": "b", "dc": 4}
+
+    async def fake_generate(*, model, prompt):
+        return "narration"
+
+    monkeypatch.setattr(engine_service, "generate", fake_generate)
+
+    asyncio.run(engine_service.submit_player_roll(game_dnd, "a", 6, 0))
+    asyncio.run(engine_service.submit_player_roll(game_d6, "b", 6, 0))
+
+    mem_dnd = engine_service._GAME_STATES[game_dnd].memory[0].content
+    mem_d6 = engine_service._GAME_STATES[game_d6].memory[0].content
+    assert "failure" in mem_dnd
+    assert "success" in mem_d6

--- a/web/src/components/RulesBadge.tsx
+++ b/web/src/components/RulesBadge.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+
+interface Props {
+  name: string
+  description: string
+}
+
+export default function RulesBadge({ name, description }: Props) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="absolute right-2 top-2 rounded bg-gray-700 px-2 py-1 text-xs"
+      >
+        {name}
+      </button>
+      {open && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+          <div className="max-w-sm rounded bg-white p-4 text-sm dark:bg-gray-800 dark:text-gray-100">
+            <h2 className="mb-2 text-lg font-bold">{name} Rules</h2>
+            <p className="whitespace-pre-wrap">{description}</p>
+            <button
+              onClick={() => setOpen(false)}
+              className="mt-4 rounded bg-blue-600 px-3 py-1 text-white"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- load rule engine based on world ruleset
- show active rules with a badge and modal on play page
- ensure ruleset swap affects roll resolution

## Testing
- `pre-commit run --files engine/rules/__init__.py server/app/engine_service.py tests/test_rule_switching.py web/src/components/RulesBadge.tsx web/src/pages/PlayPage.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaf2626b608324a40f282d7c439c67