### PR TITLE
feat: add memory tagging for companions

### DIFF
--- a/engine/context.py
+++ b/engine/context.py
@@ -54,7 +54,13 @@ def build_prompt(world: World, state: object, k: int = 5) -> str:
     memories = getattr(state, "memory", [])
     top = recall(memories, k)
     if top:
-        parts.append("Memories: " + "; ".join(m.content for m in top))
+        formatted = []
+        for m in top:
+            if m.tags:
+                formatted.append(f"{m.content} [{', '.join(m.tags)}]")
+            else:
+                formatted.append(m.content)
+        parts.append("Memories: " + "; ".join(formatted))
 
     # Rules highlights
     if world.rules_notes:

--- a/engine/memory.py
+++ b/engine/memory.py
@@ -2,26 +2,44 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Iterable, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MemoryItem(BaseModel):
-    """Represents a single memory with an importance score."""
+    """Represents a single memory with an importance score and tags."""
 
     content: str
     importance: float = 1.0
+    tags: List[str] = Field(default_factory=list)
 
 
-def remember(memories: List[MemoryItem], content: str, importance: float = 1.0) -> None:
-    """Add a memory to the list."""
-    memories.append(MemoryItem(content=content, importance=importance))
+def remember(
+    memories: List[MemoryItem],
+    content: str,
+    importance: float = 1.0,
+    tags: Optional[Iterable[str]] = None,
+) -> None:
+    """Add a memory to the list with optional ``tags``."""
+
+    memories.append(
+        MemoryItem(content=content, importance=importance, tags=list(tags or []))
+    )
 
 
-def recall(memories: List[MemoryItem], k: int = 5) -> List[MemoryItem]:
-    """Return the top-K memories sorted by importance."""
-    return sorted(memories, key=lambda m: m.importance, reverse=True)[:k]
+def recall(
+    memories: List[MemoryItem],
+    k: int = 5,
+    tags: Optional[Iterable[str]] = None,
+) -> List[MemoryItem]:
+    """Return the top-K memories filtered by ``tags`` and sorted by importance."""
+
+    items = memories
+    if tags:
+        tag_set = set(tags)
+        items = [m for m in memories if tag_set.intersection(m.tags)]
+    return sorted(items, key=lambda m: m.importance, reverse=True)[:k]
 
 
 def decay(memories: List[MemoryItem], rate: float = 0.9) -> None:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -24,3 +24,13 @@ def test_decay_reduces_importance():
     memory.decay(memories, rate=0.5)
     top = memory.recall(memories, k=1)
     assert top[0].importance == 0.5
+
+
+def test_recall_with_tags() -> None:
+    memories: list[memory.MemoryItem] = []
+    memory.remember(memories, "saved the hero", importance=1.0, tags=["deeds"])
+    memory.remember(memories, "took an arrow", importance=0.8, tags=["injuries"])
+    memory.remember(memories, "stood by the player", importance=0.9, tags=["loyalty"])
+
+    top = memory.recall(memories, tags=["loyalty"])
+    assert [m.content for m in top] == ["stood by the player"]


### PR DESCRIPTION
## Summary
- expand memory system with tag support and filtering
- surface memory tags in prompt output alongside companion personas
- test tagged recall for loyalty, injuries, and deeds

## Testing
- `pre-commit run --files engine/memory.py engine/context.py tests/test_memory.py`
- `pytest tests/test_memory.py tests/test_party.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf455b94c832482a37ed1917346da