### PR TITLE
feat: add game autosave and transcript logging

### DIFF
--- a/tests/test_autosave_logging.py
+++ b/tests/test_autosave_logging.py
@@ -1,0 +1,56 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.app import engine_service
+from engine.world_loader import World, SectionEntry
+
+
+def _setup_world_and_game(tmp_path: Path) -> int:
+    engine_service.SAVE_DIR = tmp_path
+    world = World(
+        id="w",
+        title="World",
+        ruleset="dnd5e",
+        end_goal="",
+        lore="",
+        locations=[SectionEntry(name="Start", description="")],
+        npcs=[],
+    )
+    engine_service._WORLDS[1] = world
+    game_id = engine_service.create_game(1)
+    return game_id
+
+
+def test_transcript_and_autosave(tmp_path, monkeypatch):
+    game_id = _setup_world_and_game(tmp_path)
+
+    async def fake_generate(*, model, prompt):
+        return "DM reply"
+
+    monkeypatch.setattr(engine_service, "generate", fake_generate)
+
+    state = engine_service._GAME_STATES[game_id]
+    state.flags["score"] = 7
+
+    asyncio.run(engine_service.run_turn(game_id, "hello"))
+
+    transcript = tmp_path / f"game_{game_id}.jsonl"
+    autosave = tmp_path / f"game_{game_id}.json"
+
+    assert transcript.exists() and autosave.exists()
+
+    lines = [json.loads(line) for line in transcript.read_text().splitlines()]
+    assert lines[0] == {"actor": "player", "text": "hello"}
+    assert lines[1]["actor"] == "dm"
+
+    data = json.loads(autosave.read_text())
+    assert data["flags"]["score"] == 7
+
+    engine_service._GAME_STATES.clear()
+    engine_service.load_autosave(game_id)
+    restored = engine_service._GAME_STATES[game_id]
+    assert restored.flags["score"] == 7


### PR DESCRIPTION
## Summary
- persist game state to `saves/` after each turn
- record player and DM messages in per-game JSONL transcript
- cover autosave and transcript recovery in tests

## Testing
- `pre-commit run --files server/app/engine_service.py tests/test_autosave_logging.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaf63f56488324848c9dfb05ae6e62