### PR TITLE
feat: add Makefile dev workflow and docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.RECIPEPREFIX := >
+MODEL ?= llama3
+
+.PHONY: check-ollama
+check-ollama:
+>command -v ollama >/dev/null 2>&1 || { echo 'Ollama is required: https://ollama.ai' >&2; exit 1; }
+>ollama list | awk 'NR>1 {print $$1}' | grep -q "^$(MODEL)$$" || { echo 'Model $(MODEL) not found. Pull it with: ollama pull $(MODEL)' >&2; exit 1; }
+
+.PHONY: dev
+dev: check-ollama
+>echo 'Starting backend and frontend (dev mode)...'
+>trap 'kill 0' INT TERM EXIT; \
+>uv run --directory server fastapi dev --host 0.0.0.0 --port 8000 & \
+>pnpm --dir web dev -- --host 0.0.0.0 --port 5173 & \
+>wait
+
+.PHONY: start
+start: check-ollama
+>echo 'Starting backend and frontend (prod mode)...'
+>trap 'kill 0' INT TERM EXIT; \
+>uv run --directory server fastapi run --host 0.0.0.0 --port 8000 & \
+>pnpm --dir web preview -- --host 0.0.0.0 --port 5173 & \
+>wait
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Players physically roll dice, type the results, and the AI DM continues narratio
 - [Ollama installed](https://ollama.ai/) and at least one model pulled (e.g. `llama2:13b`)
 
 ### Setup
+### One-command dev
+
+With [Ollama](https://ollama.ai) and the `llama3` model installed:
+
+```bash
+make dev
+```
+
+This launches both the FastAPI backend and the Vite frontend.
+
+### Manual setup
+
 ```bash
 # Clone repo
 git clone https://github.com/your-username/local-ai-ttrpg.git
@@ -52,7 +64,7 @@ pnpm install
 pnpm dev
 ```
 
-Backend runs on `http://localhost:8000`  
+Backend runs on `http://localhost:8000`
 Frontend runs on `http://localhost:5173`
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+services:
+  server:
+    image: ghcr.io/astral-sh/uv:latest
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: uv run --directory server fastapi run --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+  web:
+    image: node:20
+    working_dir: /app/web
+    volumes:
+      - ./web:/app/web
+    command: sh -c "corepack enable && pnpm install && pnpm dev --host 0.0.0.0 --port 5173"
+    ports:
+      - "5173:5173"
+    depends_on:
+      - server


### PR DESCRIPTION
## Summary
- add Makefile with `dev` and `start` targets that verify Ollama and run server and web together
- document one-command startup and provide optional docker-compose for full stack

## Testing
- `uv run pre-commit run --files Makefile docker-compose.yml README.md`
- `uv run --extra dev pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab8e8f59188324bfb1034473e482f3