### PR TITLE
Fix frontend TypeScript imports and API client method typing

### DIFF
--- a/web/src/api/apiClient.ts
+++ b/web/src/api/apiClient.ts
@@ -4,7 +4,9 @@ const BASE_URL = import.meta.env.VITE_API_URL ?? '';
 
 type Path = keyof paths;
 
-type Method<P extends Path> = keyof paths[P];
+// Ensure method type is narrowed to strings so we can safely call string methods
+// on it. `keyof` may include number or symbol, so we explicitly extract strings.
+type Method<P extends Path> = Extract<keyof paths[P], string>;
 
 type RequestBody<P extends Path, M extends Method<P>> =
   paths[P][M] extends { requestBody: { content: { 'application/json': infer B } } }

--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -1,8 +1,8 @@
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import ChatStream, { ChatMessage } from '../components/ChatStream'
+import ChatStream, { type ChatMessage } from '../components/ChatStream'
 import InputBar from '../components/InputBar'
-import RollPrompt, { RollRequest } from '../components/RollPrompt'
+import RollPrompt, { type RollRequest } from '../components/RollPrompt'
 import RulesBadge from '../components/RulesBadge'
 
 export default function PlayPage() {


### PR DESCRIPTION
## Summary
- Ensure API client method type is string to allow `.toUpperCase()` and fetch calls
- Use type-only imports for ChatMessage and RollRequest to satisfy TypeScript verbatim module syntax

## Testing
- `pnpm build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abadf54c188324aaa69bdbbd46581f