### PR TITLE
Add world library with upload and navigation

### DIFF
--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import ChatStream, { type ChatMessage } from '../components/ChatStream'
 import InputBar from '../components/InputBar'
@@ -9,14 +9,17 @@ export default function PlayPage() {
   const { gameId } = useParams()
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [pendingRoll, setPendingRoll] = useState<RollRequest | null>(null)
-  const [rulesInfo, setRulesInfo] = useState<
-    { label: string; instructions: string } | null
-  >(null)
+  const [rulesInfo, setRulesInfo] = useState<{
+    label: string
+    instructions: string
+  } | null>(null)
 
   useEffect(() => {
     async function loadRules() {
       const game = await fetch(`/games/${gameId}`).then((r) => r.json())
-      const world = await fetch(`/worlds/${game.world_id}`).then((r) => r.json())
+      const world = await fetch(`/worlds/${game.world_id}`).then((r) =>
+        r.json(),
+      )
       const map: Record<string, { label: string; instructions: string }> = {
         dnd5e: {
           label: 'D&D 5e',
@@ -123,23 +126,35 @@ export default function PlayPage() {
 
   return (
     <div className="relative flex h-full flex-col md:flex-row dark:bg-gray-900 dark:text-gray-100">
+      <Link
+        to="/"
+        className="absolute left-2 top-2 rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-700"
+      >
+        Home
+      </Link>
       {rulesInfo && (
         <RulesBadge
           name={rulesInfo.label}
           description={rulesInfo.instructions}
         />
       )}
-      <aside className="hidden w-64 border-r border-gray-700 p-4 md:block">Left Panel</aside>
+      <aside className="hidden w-64 border-r border-gray-700 p-4 md:block">
+        Left Panel
+      </aside>
       <main className="flex flex-1 flex-col">
         <ChatStream messages={messages} />
-        {pendingRoll && <RollPrompt request={pendingRoll} onSubmit={submitRoll} />}
+        {pendingRoll && (
+          <RollPrompt request={pendingRoll} onSubmit={submitRoll} />
+        )}
         <InputBar
           onSend={sendAction}
           onCommand={handleCommand}
           disabled={!!pendingRoll}
         />
       </main>
-      <aside className="hidden w-64 border-l border-gray-700 p-4 md:block">Right Panel</aside>
+      <aside className="hidden w-64 border-l border-gray-700 p-4 md:block">
+        Right Panel
+      </aside>
     </div>
   )
 }

--- a/web/src/pages/WorldEditorPage.tsx
+++ b/web/src/pages/WorldEditorPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 const API_BASE = import.meta.env.VITE_API_URL ?? ''
 
@@ -19,7 +19,7 @@ interface ParsedWorld {
 export default function WorldEditorPage() {
   const navigate = useNavigate()
   const [markdown, setMarkdown] = useState(
-    `---\nid: demo\ntitle: Demo World\nruleset: custom_d6\nend_goal: Have fun\n---\n\n## Lore\nDescribe your world.\n`
+    `---\nid: demo\ntitle: Demo World\nruleset: custom_d6\nend_goal: Have fun\n---\n\n## Lore\nDescribe your world.\n`,
   )
   const [preview, setPreview] = useState<ParsedWorld | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -71,7 +71,13 @@ export default function WorldEditorPage() {
   }
 
   return (
-    <div className="flex h-full flex-col bg-gray-100 dark:bg-gray-900 dark:text-gray-100">
+    <div className="relative flex h-full flex-col bg-gray-100 dark:bg-gray-900 dark:text-gray-100">
+      <Link
+        to="/"
+        className="absolute left-2 top-2 rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-700"
+      >
+        Home
+      </Link>
       <div className="flex flex-1 flex-col md:flex-row">
         <textarea
           value={markdown}
@@ -80,7 +86,9 @@ export default function WorldEditorPage() {
         />
         <div className="flex-1 overflow-auto border border-gray-700 p-2">
           {error && <p className="text-red-500">{error}</p>}
-          {preview && <pre className="text-xs">{JSON.stringify(preview, null, 2)}</pre>}
+          {preview && (
+            <pre className="text-xs">{JSON.stringify(preview, null, 2)}</pre>
+          )}
         </div>
       </div>
       <div className="border-t border-gray-700 p-2 text-right">


### PR DESCRIPTION
## Summary
- Add home navigation button to play and world editor screens
- Introduce world library page with markdown upload and play launch
- Allow starting a game by selecting a world from the library

## Testing
- `pytest`
- `npm run lint`
- `npm run typecheck`
- `npm run format` *(fails: Code style issues found in 8 files)*

------
https://chatgpt.com/codex/tasks/task_e_68abdef850cc8324ac016aa4f0723a46