### PR TITLE
Return 400 for invalid world uploads

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -51,7 +51,10 @@ class WorldImport(BaseModel):
 
 @app.post("/worlds/import")
 def import_world_endpoint(payload: WorldImport) -> dict[str, int]:
-    new_id = import_world(payload.content)
+    try:
+        new_id = import_world(payload.content)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"id": new_id}
 
 

--- a/tests/test_world_import_error.py
+++ b/tests/test_world_import_error.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from server.app.main import app
+
+
+def test_import_invalid_world_returns_400():
+    client = TestClient(app)
+    invalid_md = "---\n---\n"  # Missing required fields
+    response = client.post("/worlds/import", json={"content": invalid_md})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- return 400 when world import fails validation
- test invalid world upload

## Testing
- `ruff check server/app/main.py tests/test_world_import_error.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abe605eac88324a12d3348f6deed4a