### PR TITLE
Add ammo and damage mechanics to SimpleD20 ruleset

### DIFF
--- a/engine/rules/__init__.py
+++ b/engine/rules/__init__.py
@@ -3,10 +3,12 @@
 from .base import RuleSystem
 from .dnd5e import DnD5eRules
 from .custom_d6 import CustomD6Rules
+from .simple_d20 import SimpleD20Rules
 
 _RULESET_MAP = {
     "dnd5e": DnD5eRules,
     "custom_d6": CustomD6Rules,
+    "simple_d20": SimpleD20Rules,
 }
 
 
@@ -34,5 +36,6 @@ __all__ = [
     "RuleSystem",
     "DnD5eRules",
     "CustomD6Rules",
+    "SimpleD20Rules",
     "get_ruleset",
 ]

--- a/engine/rules/simple_d20.py
+++ b/engine/rules/simple_d20.py
@@ -1,0 +1,71 @@
+"""Light-weight d20 rules with simple attack resolution."""
+
+from __future__ import annotations
+
+import random
+
+from .base import RuleSystem
+
+
+class SimpleD20Rules(RuleSystem):
+    """Basic d20 mechanics with ammunition and damage dice."""
+
+    MAX_BONUS = 6
+
+    def roll_check(
+        self, bonus: int, dc: int, roll: int | None = None
+    ) -> tuple[bool, int]:
+        roll = roll if roll is not None else random.randint(1, 20)
+        capped = min(bonus, self.MAX_BONUS)
+        total = roll + capped
+        return total >= dc, total
+
+    def resolve_player_roll(self, roll: int, bonus: int, dc: int) -> tuple[bool, int]:
+        capped = min(bonus, self.MAX_BONUS)
+        total = roll + capped
+        return total >= dc, total
+
+    def apply_damage(self, hp: int, damage: int) -> int:
+        return max(hp - damage, 0)
+
+    def _roll_damage(self, die: str, roll: int | None = None) -> int:
+        count_str, size_str = die.lower().split("d")
+        count = int(count_str) if count_str else 1
+        size = int(size_str)
+        if roll is not None:
+            return roll
+        return sum(random.randint(1, size) for _ in range(count))
+
+    def resolve_attack(
+        self,
+        hp: int,
+        bonus: int,
+        dc: int,
+        damage_die: str,
+        ammo: int,
+        roll: int | None = None,
+        damage_roll: int | None = None,
+    ) -> tuple[int, int, bool, int]:
+        if ammo <= 0:
+            return hp, ammo, False, 0
+        success, _total = self.roll_check(bonus, dc, roll)
+        ammo -= 1
+        if success:
+            damage = self._roll_damage(damage_die, damage_roll)
+            hp = self.apply_damage(hp, damage)
+            return hp, ammo, True, damage
+        return hp, ammo, False, 0
+
+    @property
+    def system_instructions(self) -> str:  # pragma: no cover - static text
+        return (
+            "Roll a d20 and add modifiers up to +6. Checks succeed if the total "
+            "meets or exceeds the DC. Attacks consume one ammo and roll weapon "
+            "damage only on a hit."
+        )
+
+    def format_roll_explanation(self, roll: int, bonus: int, dc: int) -> str:
+        capped = min(bonus, self.MAX_BONUS)
+        total = roll + capped
+        outcome = "success" if total >= dc else "failure"
+        return f"rolled {roll} + {capped} = {total} vs DC {dc} -> {outcome}"

--- a/tests/test_rule_switching.py
+++ b/tests/test_rule_switching.py
@@ -24,10 +24,13 @@ def _make_world(idx: int, ruleset: str) -> None:
 def test_submit_roll_uses_world_rules(monkeypatch):
     _make_world(1, "dnd5e")
     _make_world(2, "custom_d6")
+    _make_world(3, "simple_d20")
     game_dnd = engine_service.create_game(1)
     game_d6 = engine_service.create_game(2)
+    game_d20 = engine_service.create_game(3)
     engine_service._GAME_STATES[game_dnd].pending_roll = {"id": "a", "dc": 10}
     engine_service._GAME_STATES[game_d6].pending_roll = {"id": "b", "dc": 4}
+    engine_service._GAME_STATES[game_d20].pending_roll = {"id": "c", "dc": 10}
 
     async def fake_generate(*, model, prompt):
         return "narration"
@@ -36,8 +39,11 @@ def test_submit_roll_uses_world_rules(monkeypatch):
 
     asyncio.run(engine_service.submit_player_roll(game_dnd, "a", 6, 0))
     asyncio.run(engine_service.submit_player_roll(game_d6, "b", 6, 0))
+    asyncio.run(engine_service.submit_player_roll(game_d20, "c", 10, 0))
 
     mem_dnd = engine_service._GAME_STATES[game_dnd].memory[0].content
     mem_d6 = engine_service._GAME_STATES[game_d6].memory[0].content
+    mem_d20 = engine_service._GAME_STATES[game_d20].memory[0].content
     assert "failure" in mem_dnd
     assert "success" in mem_d6
+    assert "success" in mem_d20

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from engine.rules import CustomD6Rules, DnD5eRules
+from engine.rules import CustomD6Rules, DnD5eRules, SimpleD20Rules
 
 
 def test_dnd5e_roll_check_success():
@@ -40,3 +40,64 @@ def test_format_explanation():
     rules = DnD5eRules()
     text = rules.format_roll_explanation(roll=10, bonus=2, dc=15)
     assert "rolled 10 + 2 = 12 vs DC 15" in text
+
+
+def test_simple_d20_roll_check_and_cap():
+    rules = SimpleD20Rules()
+    success, total = rules.roll_check(bonus=8, dc=18, roll=12)
+    assert success is True
+    assert total == 18
+    success, _ = rules.roll_check(bonus=0, dc=10, roll=5)
+    assert success is False
+    assert rules.apply_damage(hp=5, damage=10) == 0
+
+
+def test_simple_d20_attack_damage_and_ammo():
+    rules = SimpleD20Rules()
+    hp, ammo, success, dmg = rules.resolve_attack(
+        hp=10,
+        bonus=0,
+        dc=10,
+        damage_die="1d6",
+        ammo=2,
+        roll=10,
+        damage_roll=4,
+    )
+    assert success is True
+    assert dmg == 4
+    assert hp == 6
+    assert ammo == 1
+
+
+def test_simple_d20_attack_miss_no_damage():
+    rules = SimpleD20Rules()
+    hp, ammo, success, dmg = rules.resolve_attack(
+        hp=10,
+        bonus=0,
+        dc=15,
+        damage_die="1d6",
+        ammo=2,
+        roll=5,
+        damage_roll=6,
+    )
+    assert success is False
+    assert dmg == 0
+    assert hp == 10
+    assert ammo == 1
+
+
+def test_simple_d20_attack_requires_ammo():
+    rules = SimpleD20Rules()
+    hp, ammo, success, dmg = rules.resolve_attack(
+        hp=10,
+        bonus=0,
+        dc=10,
+        damage_die="1d6",
+        ammo=0,
+        roll=15,
+        damage_roll=6,
+    )
+    assert success is False
+    assert dmg == 0
+    assert hp == 10
+    assert ammo == 0


### PR DESCRIPTION
## Summary
- cap check bonuses at +6 and clarify roll explanations
- add ammo usage and weapon damage dice with `resolve_attack`
- expand tests to cover bonus caps, ammo consumption, and hit/miss damage

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf1f650308324bcfe33ab6c9ae070