### PR TITLE
Enable CORS for world imports

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException, Response
+from fastapi.middleware.cors import CORSMiddleware
 import httpx
 from pydantic import BaseModel
 from typing import Any, Dict
@@ -22,6 +23,13 @@ from .llm.ollama_client import list_models
 from engine.world_loader import dump_world
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/health")

--- a/tests/test_cors_headers.py
+++ b/tests/test_cors_headers.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.app.main import app
+
+
+def test_cors_headers_present():
+    client = TestClient(app)
+    resp = client.get("/worlds", headers={"Origin": "http://localhost:5173"})
+    assert resp.headers.get("access-control-allow-origin") == "*"


### PR DESCRIPTION
## Summary
- Allow cross-origin requests in FastAPI app so the web client can import worlds without connection errors
- Test that CORS headers are returned for API requests

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac19dbbcec83248716075b14e421c7