### PR TITLE
fix(web): default API base to local server

### DIFF
--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -5,6 +5,8 @@ import InputBar from '../components/InputBar'
 import RollPrompt, { type RollRequest } from '../components/RollPrompt'
 import RulesBadge from '../components/RulesBadge'
 
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
+
 export default function PlayPage() {
   const { gameId } = useParams()
   const [messages, setMessages] = useState<ChatMessage[]>([])
@@ -16,8 +18,8 @@ export default function PlayPage() {
 
   useEffect(() => {
     async function loadRules() {
-      const game = await fetch(`/games/${gameId}`).then((r) => r.json())
-      const world = await fetch(`/worlds/${game.world_id}`).then((r) =>
+      const game = await fetch(`${API_BASE}/games/${gameId}`).then((r) => r.json())
+      const world = await fetch(`${API_BASE}/worlds/${game.world_id}`).then((r) =>
         r.json(),
       )
       const map: Record<string, { label: string; instructions: string }> = {
@@ -46,7 +48,7 @@ export default function PlayPage() {
     setMessages((prev) => [...prev, playerMsg])
 
     try {
-      const resp = await fetch(`/games/${gameId}/turn`, {
+      const resp = await fetch(`${API_BASE}/games/${gameId}/turn`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: text }),
@@ -82,7 +84,7 @@ export default function PlayPage() {
       content: `Roll ${value}${mod ? ` + ${mod}` : ''}`,
     }
     setMessages((prev) => [...prev, playerMsg])
-    const resp = await fetch(`/games/${gameId}/player-roll`, {
+    const resp = await fetch(`${API_BASE}/games/${gameId}/player-roll`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/web/src/pages/WorldEditorPage.tsx
+++ b/web/src/pages/WorldEditorPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
-const API_BASE = import.meta.env.VITE_API_URL ?? ''
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
 
 interface ParsedWorld {
   id: string

--- a/web/src/pages/WorldsPage.tsx
+++ b/web/src/pages/WorldsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
-const API_BASE = import.meta.env.VITE_API_URL ?? ''
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
 
 interface WorldSummary {
   id: number


### PR DESCRIPTION
## Summary
- default frontend API base to `http://localhost:8000` when env var missing
- route all fetch calls through this base to reach FastAPI backend

## Testing
- `pre-commit run --files web/src/pages/PlayPage.tsx web/src/pages/WorldEditorPage.tsx web/src/pages/WorldsPage.tsx`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac1cd047888324bc8d105641fa01c1