### PR TITLE
Add campaign settings and party panel

### DIFF
--- a/web/src/components/PartyPanel.tsx
+++ b/web/src/components/PartyPanel.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+export interface Character {
+  id: number | string
+  name: string
+  stats?: Record<string, number>
+  inventory?: string[]
+  status?: string
+}
+
+interface Props {
+  party: Character[]
+}
+
+export default function PartyPanel({ party }: Props) {
+  if (!party.length) return <div className="text-sm">No party members</div>
+  const [player, ...others] = party
+  return (
+    <div className="space-y-4 text-sm">
+      <div>
+        <h3 className="font-semibold">Player</h3>
+        <div className="mt-1 rounded border border-gray-700 p-2">
+          <div className="font-medium">{player.name}</div>
+          {player.stats && (
+            <div>HP: {player.stats.hp ?? 0}</div>
+          )}
+          {player.inventory && player.inventory.length > 0 && (
+            <div>Inventory: {player.inventory.join(', ')}</div>
+          )}
+          {player.status && <div>Status: {player.status}</div>}
+        </div>
+      </div>
+      {others.length > 0 && (
+        <div>
+          <h3 className="font-semibold">Party</h3>
+          <div className="space-y-2">
+            {others.map((m) => (
+              <div
+                key={m.id}
+                className="rounded border border-gray-700 p-2"
+              >
+                <div className="font-medium">{m.name}</div>
+                {m.stats && <div>HP: {m.stats.hp ?? 0}</div>}
+                {m.inventory && m.inventory.length > 0 && (
+                  <div>Inventory: {m.inventory.join(', ')}</div>
+                )}
+                {m.status && <div>Status: {m.status}</div>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import HomePage from './pages/HomePage.tsx'
 import PlayPage from './pages/PlayPage.tsx'
 import WorldsPage from './pages/WorldsPage.tsx'
 import WorldEditorPage from './pages/WorldEditorPage.tsx'
+import SettingsPage from './pages/SettingsPage.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -16,6 +17,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/play/:gameId" element={<PlayPage />} />
         <Route path="/worlds" element={<WorldsPage />} />
         <Route path="/worlds/new" element={<WorldEditorPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/web/src/pages/HomePage.tsx
+++ b/web/src/pages/HomePage.tsx
@@ -13,6 +13,9 @@ export default function HomePage() {
       <Link to="/worlds" className="text-blue-500 underline">
         Browse Worlds
       </Link>
+      <Link to="/settings" className="text-blue-500 underline">
+        Settings
+      </Link>
     </div>
   )
 }

--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -4,6 +4,7 @@ import ChatStream, { type ChatMessage } from '../components/ChatStream'
 import InputBar from '../components/InputBar'
 import RollPrompt, { type RollRequest } from '../components/RollPrompt'
 import RulesBadge from '../components/RulesBadge'
+import PartyPanel, { type Character } from '../components/PartyPanel'
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
 
@@ -16,6 +17,10 @@ export default function PlayPage() {
     instructions: string
   } | null>(null)
   const [worldTitle, setWorldTitle] = useState<string | null>(null)
+  const [party, setParty] = useState<Character[]>([])
+  const [model] = useState<string>(
+    () => localStorage.getItem('model') ?? 'llama3',
+  )
 
   useEffect(() => {
     async function loadRules() {
@@ -23,6 +28,7 @@ export default function PlayPage() {
       const world = await fetch(`${API_BASE}/worlds/${game.world_id}`).then((r) =>
         r.json(),
       )
+      setParty(game.party ?? [])
       const map: Record<string, { label: string; instructions: string }> = {
         dnd5e: {
           label: 'D&D 5e',
@@ -53,7 +59,7 @@ export default function PlayPage() {
       const resp = await fetch(`${API_BASE}/games/${gameId}/turn`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: text }),
+        body: JSON.stringify({ message: text, model }),
       })
       if (!resp.ok) throw new Error('request failed')
       const data = await resp.json()
@@ -136,6 +142,12 @@ export default function PlayPage() {
       >
         Home
       </Link>
+      <Link
+        to="/settings"
+        className="absolute right-2 top-2 rounded bg-gray-700 px-2 py-1 text-white hover:bg-gray-800"
+      >
+        Settings
+      </Link>
       {rulesInfo && (
         <RulesBadge
           name={rulesInfo.label}
@@ -160,7 +172,7 @@ export default function PlayPage() {
         />
       </main>
       <aside className="hidden w-64 border-l border-gray-700 p-4 pt-10 md:block">
-        {/* Right Panel */}
+        <PartyPanel party={party} />
       </aside>
     </div>
   )

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
+
+type WorldData = {
+  lore: string
+  rules_notes?: string
+  npcs: { name: string; description: string }[]
+}
+
+type PartyMember = {
+  id: number | string
+  name: string
+  stats?: Record<string, number>
+  inventory?: string[]
+}
+
+export default function SettingsPage() {
+  const [models, setModels] = useState<string[]>([])
+  const [model, setModel] = useState(
+    () => localStorage.getItem('model') ?? 'llama3',
+  )
+
+  // world editing
+  const [worldId, setWorldId] = useState('')
+  const [world, setWorld] = useState<WorldData | null>(null)
+
+  // party editing
+  const [gameId, setGameId] = useState('')
+  const [party, setParty] = useState<PartyMember[]>([])
+
+  useEffect(() => {
+    fetch(`${API_BASE}/health/llm`)
+      .then((r) => r.json())
+      .then((d) => setModels(d.models ?? []))
+      .catch(() => setModels([]))
+  }, [])
+
+  function saveModel() {
+    localStorage.setItem('model', model)
+    alert('Model saved')
+  }
+
+  async function loadWorld() {
+    if (!worldId) return
+    const data = await fetch(`${API_BASE}/worlds/${worldId}`).then((r) => r.json())
+    setWorld(data)
+  }
+
+  async function saveWorld() {
+    if (!worldId) return
+    await fetch(`${API_BASE}/worlds/${worldId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        lore: world.lore,
+        rules_notes: world.rules_notes,
+        npcs: world.npcs,
+      }),
+    })
+    alert('World saved')
+  }
+
+  async function loadGame() {
+    if (!gameId) return
+    const data = await fetch(`${API_BASE}/games/${gameId}`).then((r) => r.json())
+    setParty(data.party ?? [])
+  }
+
+  async function saveMember(idx: number) {
+    const member = party[idx]
+    await fetch(`${API_BASE}/games/${gameId}/party/${member.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(member),
+    })
+  }
+
+  return (
+    <div className="space-y-6 p-4">
+      <h1 className="text-xl font-bold">Settings</h1>
+
+      <section>
+        <h2 className="font-semibold">Model</h2>
+        <select
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          className="border p-1"
+        >
+          {models.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={saveModel}
+          className="ml-2 rounded bg-blue-600 px-2 py-1 text-white"
+        >
+          Save
+        </button>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="font-semibold">World Editor</h2>
+        <div className="space-x-2">
+          <input
+            value={worldId}
+            onChange={(e) => setWorldId(e.target.value)}
+            placeholder="World ID"
+            className="w-24 border p-1"
+          />
+          <button
+            onClick={loadWorld}
+            className="rounded bg-gray-700 px-2 py-1 text-white"
+          >
+            Load
+          </button>
+          {world && (
+            <button
+              onClick={saveWorld}
+              className="rounded bg-blue-600 px-2 py-1 text-white"
+            >
+              Save
+            </button>
+          )}
+        </div>
+        {world && (
+          <div className="space-y-2">
+            <div>
+              <label className="block text-sm font-medium">Lore</label>
+              <textarea
+                value={world.lore}
+                onChange={(e) => setWorld({ ...world, lore: e.target.value })}
+                className="h-24 w-full border p-1"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium">Rules Notes</label>
+              <textarea
+                value={world.rules_notes ?? ''}
+                onChange={(e) =>
+                  setWorld({ ...world, rules_notes: e.target.value })
+                }
+                className="h-24 w-full border p-1"
+              />
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="font-semibold">Party Editor</h2>
+        <div className="space-x-2">
+          <input
+            value={gameId}
+            onChange={(e) => setGameId(e.target.value)}
+            placeholder="Game ID"
+            className="w-24 border p-1"
+          />
+          <button
+            onClick={loadGame}
+            className="rounded bg-gray-700 px-2 py-1 text-white"
+          >
+            Load
+          </button>
+        </div>
+        {party.map((m, idx) => (
+          <div key={m.id} className="rounded border p-2">
+            <div className="flex items-center gap-2">
+              <input
+                value={m.name}
+                onChange={(e) => {
+                  const copy = [...party]
+                  copy[idx] = { ...copy[idx], name: e.target.value }
+                  setParty(copy)
+                }}
+                className="border p-1"
+              />
+              <button
+                onClick={() => saveMember(idx)}
+                className="rounded bg-blue-600 px-2 py-1 text-white"
+              >
+                Save
+              </button>
+            </div>
+            {m.stats && (
+              <div className="mt-2 text-sm">
+                HP:{' '}
+                <input
+                  type="number"
+                  value={m.stats.hp ?? 0}
+                  onChange={(e) => {
+                    const copy = [...party]
+                    copy[idx] = {
+                      ...copy[idx],
+                      stats: { ...copy[idx].stats, hp: Number(e.target.value) },
+                    }
+                    setParty(copy)
+                  }}
+                  className="w-16 border p-1"
+                />
+              </div>
+            )}
+            {m.inventory && (
+              <div className="mt-2 text-sm">
+                Inventory (comma separated):
+                <input
+                  value={m.inventory.join(', ')}
+                  onChange={(e) => {
+                    const items = e.target.value
+                      .split(',')
+                      .map((s) => s.trim())
+                      .filter(Boolean)
+                    const copy = [...party]
+                    copy[idx] = { ...copy[idx], inventory: items }
+                    setParty(copy)
+                  }}
+                  className="ml-2 w-full border p-1"
+                />
+              </div>
+            )}
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Display player and party details in a new side panel during play
- Introduce configurable settings page for model selection and campaign editing
- Support party member and world updates via new API endpoints

## Testing
- `pnpm --dir web lint`
- `pnpm --dir web typecheck`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac23add010832498a2ff9d76ea8dc3