### PR TITLE
feat: add character creation form

### DIFF
--- a/web/src/components/CreateCharacterForm.tsx
+++ b/web/src/components/CreateCharacterForm.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
+
+export interface NewCharacter {
+  id: number | string
+  name: string
+  background?: string
+  traits?: string
+  stats: Record<string, number>
+  inventory: string[]
+}
+
+interface Props {
+  gameId: string
+  onCreated: (character: NewCharacter) => void
+}
+
+export default function CreateCharacterForm({ gameId, onCreated }: Props) {
+  const [name, setName] = useState('')
+  const [background, setBackground] = useState('')
+  const [traits, setTraits] = useState('')
+  const [hp, setHp] = useState(10)
+  const [strength, setStrength] = useState(0)
+  const [defense, setDefense] = useState(0)
+  const [inventory, setInventory] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const character: NewCharacter = {
+      id: 1,
+      name,
+      background: background || undefined,
+      traits: traits || undefined,
+      stats: { hp, strength, defense },
+      inventory: inventory
+        .split(',')
+        .map((i) => i.trim())
+        .filter((i) => i.length > 0),
+    }
+
+    await fetch(`${API_BASE}/games/${gameId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ party: [character] }),
+    })
+
+    onCreated(character)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 text-sm">
+      <div>
+        <label className="block">Name</label>
+        <input
+          className="w-full rounded border border-gray-700 bg-gray-800 p-1"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block">Background</label>
+        <textarea
+          className="w-full rounded border border-gray-700 bg-gray-800 p-1"
+          value={background}
+          onChange={(e) => setBackground(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block">Traits</label>
+        <textarea
+          className="w-full rounded border border-gray-700 bg-gray-800 p-1"
+          value={traits}
+          onChange={(e) => setTraits(e.target.value)}
+        />
+      </div>
+      <div className="flex gap-2">
+        <div>
+          <label className="block">HP</label>
+          <input
+            type="number"
+            className="w-20 rounded border border-gray-700 bg-gray-800 p-1"
+            value={hp}
+            onChange={(e) => setHp(Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <label className="block">Strength</label>
+          <input
+            type="number"
+            className="w-20 rounded border border-gray-700 bg-gray-800 p-1"
+            value={strength}
+            onChange={(e) => setStrength(Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <label className="block">Defense</label>
+          <input
+            type="number"
+            className="w-20 rounded border border-gray-700 bg-gray-800 p-1"
+            value={defense}
+            onChange={(e) => setDefense(Number(e.target.value))}
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block">Starting Inventory (comma separated)</label>
+        <input
+          className="w-full rounded border border-gray-700 bg-gray-800 p-1"
+          value={inventory}
+          onChange={(e) => setInventory(e.target.value)}
+        />
+      </div>
+      <button
+        type="submit"
+        className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-700"
+      >
+        Create Character
+      </button>
+    </form>
+  )
+}

--- a/web/src/components/PartyPanel.tsx
+++ b/web/src/components/PartyPanel.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 export interface Character {
   id: number | string
   name: string
+  background?: string
+  traits?: string
   stats?: Record<string, number>
   inventory?: string[]
   status?: string
@@ -22,8 +24,18 @@ export default function PartyPanel({ party }: Props) {
         <div className="mt-1 rounded border border-gray-700 p-2">
           <div className="font-medium">{player.name}</div>
           {player.stats && (
-            <div>HP: {player.stats.hp ?? 0}</div>
+            <div>
+              <div>HP: {player.stats.hp ?? 0}</div>
+              {player.stats.strength !== undefined && (
+                <div>STR: {player.stats.strength}</div>
+              )}
+              {player.stats.defense !== undefined && (
+                <div>DEF: {player.stats.defense}</div>
+              )}
+            </div>
           )}
+          {player.background && <div>Background: {player.background}</div>}
+          {player.traits && <div>Traits: {player.traits}</div>}
           {player.inventory && player.inventory.length > 0 && (
             <div>Inventory: {player.inventory.join(', ')}</div>
           )}
@@ -40,7 +52,19 @@ export default function PartyPanel({ party }: Props) {
                 className="rounded border border-gray-700 p-2"
               >
                 <div className="font-medium">{m.name}</div>
-                {m.stats && <div>HP: {m.stats.hp ?? 0}</div>}
+                {m.stats && (
+                  <div>
+                    <div>HP: {m.stats.hp ?? 0}</div>
+                    {m.stats.strength !== undefined && (
+                      <div>STR: {m.stats.strength}</div>
+                    )}
+                    {m.stats.defense !== undefined && (
+                      <div>DEF: {m.stats.defense}</div>
+                    )}
+                  </div>
+                )}
+                {m.background && <div>Background: {m.background}</div>}
+                {m.traits && <div>Traits: {m.traits}</div>}
                 {m.inventory && m.inventory.length > 0 && (
                   <div>Inventory: {m.inventory.join(', ')}</div>
                 )}

--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -5,6 +5,9 @@ import InputBar from '../components/InputBar'
 import RollPrompt, { type RollRequest } from '../components/RollPrompt'
 import RulesBadge from '../components/RulesBadge'
 import PartyPanel, { type Character } from '../components/PartyPanel'
+import CreateCharacterForm, {
+  type NewCharacter,
+} from '../components/CreateCharacterForm'
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
 
@@ -18,6 +21,7 @@ export default function PlayPage() {
   } | null>(null)
   const [worldTitle, setWorldTitle] = useState<string | null>(null)
   const [party, setParty] = useState<Character[]>([])
+  const [showCreator, setShowCreator] = useState(false)
   const [model] = useState<string>(
     () => localStorage.getItem('model') ?? 'llama3',
   )
@@ -178,7 +182,26 @@ export default function PlayPage() {
         />
       </main>
       <aside className="hidden w-64 border-l border-gray-700 p-4 pt-10 md:block">
-        <PartyPanel party={party} />
+        {party.length === 0 ? (
+          showCreator ? (
+            <CreateCharacterForm
+              gameId={gameId!}
+              onCreated={(c: NewCharacter) => {
+                setParty([c])
+                setShowCreator(false)
+              }}
+            />
+          ) : (
+            <button
+              onClick={() => setShowCreator(true)}
+              className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-700"
+            >
+              Create Character
+            </button>
+          )
+        ) : (
+          <PartyPanel party={party} />
+        )}
       </aside>
     </div>
   )


### PR DESCRIPTION
## Summary
- add UI form to create a player character
- show button when no player exists and display character details
- expand party panel to show background, traits, and stats

## Testing
- `pre-commit run --files web/src/components/CreateCharacterForm.tsx web/src/components/PartyPanel.tsx web/src/pages/PlayPage.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac30e376ac8324b00a582eb7baab94