### PR TITLE
Hide reasoning tokens in LLM output

### DIFF
--- a/tests/test_thinking_tokens.py
+++ b/tests/test_thinking_tokens.py
@@ -1,0 +1,14 @@
+"""Test filtering of reasoning tokens in ollama client."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.app.llm.ollama_client import _strip_thinking_tags
+
+
+def test_strip_thinking_tags():
+    text = "Visible<think>hidden reasoning</think>output"
+    assert _strip_thinking_tags(text) == "Visibleoutput"
+


### PR DESCRIPTION
## Summary
- filter `<think>` sections from generate and streaming outputs
- cover token stripping with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac34ffaad8832495a728ad245ac497