### PR TITLE
Enforce world-specific stat limits

### DIFF
--- a/engine/world_loader.py
+++ b/engine/world_loader.py
@@ -23,6 +23,7 @@ class World(BaseModel):
     id: str
     title: str
     ruleset: str
+    stats: List[str] = []
     end_goal: str
     lore: str
     locations: List[SectionEntry]
@@ -87,6 +88,7 @@ def _build_world(post: frontmatter.Post) -> World:
         id=str(post["id"]),
         title=str(post["title"]),
         ruleset=str(post["ruleset"]),
+        stats=list(post.get("stats", [])),
         end_goal=str(post["end_goal"]),
         lore=sections.get("Lore", ""),
         locations=_parse_entries(sections.get("Locations", "")),
@@ -119,12 +121,18 @@ def dump_world(world: World) -> str:
         f"id: {world.id}",
         f"title: {world.title}",
         f"ruleset: {world.ruleset}",
-        f"end_goal: {world.end_goal}",
-        "---",
-        "",
-        "## Lore",
-        world.lore,
     ]
+    if world.stats:
+        lines.append(f"stats: [{', '.join(world.stats)}]")
+    lines.extend(
+        [
+            f"end_goal: {world.end_goal}",
+            "---",
+            "",
+            "## Lore",
+            world.lore,
+        ]
+    )
 
     if world.locations:
         lines.append("\n## Locations")

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -93,6 +93,7 @@ class WorldUpdate(BaseModel):
     lore: str | None = None
     npcs: list[Dict[str, str]] | None = None
     rules_notes: str | None = None
+    stats: list[str] | None = None
 
 
 @app.patch("/worlds/{world_id}")
@@ -195,6 +196,8 @@ def update_party_member_endpoint(
         update_party_member(game_id, member_id, payload.model_dump(exclude_unset=True))
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok"}
 
 
@@ -211,6 +214,8 @@ def update_game_endpoint(game_id: int, payload: GameUpdate) -> dict[str, str]:
         update_game_state(game_id, payload.model_dump(exclude_unset=True))
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok"}
 
 

--- a/tests/test_stat_limits.py
+++ b/tests/test_stat_limits.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.app.main import app
+from server.app import engine_service
+from engine.world_loader import World, SectionEntry
+
+
+def setup_world():
+    engine_service._GAME_STATES.clear()
+    engine_service._WORLDS.clear()
+    world = World(
+        id="w1",
+        title="World",
+        ruleset="simple_d20",
+        stats=["tech", "firearms"],
+        end_goal="",
+        lore="",
+        locations=[SectionEntry(name="Town", description="")],
+        npcs=[],
+    )
+    engine_service._WORLDS[1] = world
+    return engine_service.create_game(1)
+
+
+def test_stat_name_restriction():
+    game_id = setup_world()
+    client = TestClient(app)
+    payload = {"party": [{"id": 1, "name": "Hero", "stats": {"hp": 10, "tech": 3}}]}
+    assert client.patch(f"/games/{game_id}", json=payload).status_code == 200
+
+    bad_payload = {
+        "party": [{"id": 1, "name": "Hero", "stats": {"hp": 10, "strength": 1}}]
+    }
+    resp = client.patch(f"/games/{game_id}", json=bad_payload)
+    assert resp.status_code == 400
+
+
+def test_stat_value_cap():
+    game_id = setup_world()
+    client = TestClient(app)
+    payload = {"party": [{"id": 1, "name": "Hero", "stats": {"hp": 10, "tech": 7}}]}
+    resp = client.patch(f"/games/{game_id}", json=payload)
+    assert resp.status_code == 400

--- a/web/src/components/CreateCharacterForm.tsx
+++ b/web/src/components/CreateCharacterForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
 
@@ -13,17 +13,23 @@ export interface NewCharacter {
 
 interface Props {
   gameId: string
+  statKeys: string[]
   onCreated: (character: NewCharacter) => void
 }
 
-export default function CreateCharacterForm({ gameId, onCreated }: Props) {
+export default function CreateCharacterForm({ gameId, statKeys, onCreated }: Props) {
   const [name, setName] = useState('')
   const [background, setBackground] = useState('')
   const [traits, setTraits] = useState('')
   const [hp, setHp] = useState(10)
-  const [strength, setStrength] = useState(0)
-  const [defense, setDefense] = useState(0)
+  const [stats, setStats] = useState<Record<string, number>>({})
   const [inventory, setInventory] = useState('')
+
+  useEffect(() => {
+    const initial: Record<string, number> = {}
+    for (const k of statKeys) initial[k] = 0
+    setStats(initial)
+  }, [statKeys])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -32,7 +38,7 @@ export default function CreateCharacterForm({ gameId, onCreated }: Props) {
       name,
       background: background || undefined,
       traits: traits || undefined,
-      stats: { hp, strength, defense },
+      stats: { hp, ...stats },
       inventory: inventory
         .split(',')
         .map((i) => i.trim())
@@ -75,7 +81,7 @@ export default function CreateCharacterForm({ gameId, onCreated }: Props) {
           onChange={(e) => setTraits(e.target.value)}
         />
       </div>
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <div>
           <label className="block">HP</label>
           <input
@@ -85,24 +91,20 @@ export default function CreateCharacterForm({ gameId, onCreated }: Props) {
             onChange={(e) => setHp(Number(e.target.value))}
           />
         </div>
-        <div>
-          <label className="block">Strength</label>
-          <input
-            type="number"
-            className="w-20 rounded border border-gray-700 bg-gray-800 p-1"
-            value={strength}
-            onChange={(e) => setStrength(Number(e.target.value))}
-          />
-        </div>
-        <div>
-          <label className="block">Defense</label>
-          <input
-            type="number"
-            className="w-20 rounded border border-gray-700 bg-gray-800 p-1"
-            value={defense}
-            onChange={(e) => setDefense(Number(e.target.value))}
-          />
-        </div>
+        {statKeys.map((key) => (
+          <div key={key}>
+            <label className="block capitalize">{key}</label>
+            <input
+              type="number"
+              max={6}
+              className="w-20 rounded border border-gray-700 bg-gray-800 p-1"
+              value={stats[key] ?? 0}
+              onChange={(e) =>
+                setStats((prev) => ({ ...prev, [key]: Number(e.target.value) }))
+              }
+            />
+          </div>
+        ))}
       </div>
       <div>
         <label className="block">Starting Inventory (comma separated)</label>

--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -22,6 +22,7 @@ export default function PlayPage() {
   const [worldTitle, setWorldTitle] = useState<string | null>(null)
   const [party, setParty] = useState<Character[]>([])
   const [showCreator, setShowCreator] = useState(false)
+  const [statKeys, setStatKeys] = useState<string[]>([])
   const [model] = useState<string>(
     () => localStorage.getItem('model') ?? 'llama3',
   )
@@ -39,6 +40,7 @@ export default function PlayPage() {
         r.json(),
       )
       setParty(game.party ?? [])
+      setStatKeys(world.stats ?? [])
       const map: Record<string, { label: string; instructions: string }> = {
         dnd5e: {
           label: 'D&D 5e',
@@ -186,6 +188,7 @@ export default function PlayPage() {
           showCreator ? (
             <CreateCharacterForm
               gameId={gameId!}
+              statKeys={statKeys}
               onCreated={(c: NewCharacter) => {
                 setParty([c])
                 setShowCreator(false)


### PR DESCRIPTION
## Summary
- support configurable stat lists per world
- validate party stats against world rules and +6 cap
- allow dynamic stat fields when creating characters

## Testing
- `pre-commit run --files engine/world_loader.py server/app/engine_service.py server/app/main.py tests/test_stat_limits.py web/src/pages/PlayPage.tsx web/src/components/CreateCharacterForm.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac3123700483249099141a537254f1