### PR TITLE
feat: allow drag and drop world import

### DIFF
--- a/web/src/pages/WorldsPage.tsx
+++ b/web/src/pages/WorldsPage.tsx
@@ -24,28 +24,47 @@ export default function WorldsPage() {
     fetchWorlds()
   }, [])
 
+  async function importFile(file: File) {
+    const content = await file.text()
+    const res = await fetch(`${API_BASE}/worlds/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    })
+    if (!res.ok) {
+      const message = await res.text()
+      alert(`Import failed: ${message}`)
+      return
+    }
+    await fetchWorlds()
+  }
+
   async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
-    const content = await file.text()
     try {
-      const res = await fetch(`${API_BASE}/worlds/import`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content }),
-      })
-      if (!res.ok) {
-        const message = await res.text()
-        alert(`Import failed: ${message}`)
-        return
-      }
-      await fetchWorlds()
+      await importFile(file)
     } catch (err) {
       console.error(err)
       alert('Import failed')
     } finally {
       e.target.value = ''
     }
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+    const file = e.dataTransfer.files?.[0]
+    if (file) {
+      importFile(file).catch((err) => {
+        console.error(err)
+        alert('Import failed')
+      })
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
   }
 
   async function handlePlay(worldId: number) {
@@ -60,7 +79,11 @@ export default function WorldsPage() {
   }
 
   return (
-    <div className="flex h-full flex-col items-center gap-4 bg-gray-100 p-4 dark:bg-gray-900 dark:text-gray-100">
+    <div
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      className="flex h-full flex-col items-center gap-4 bg-gray-100 p-4 dark:bg-gray-900 dark:text-gray-100"
+    >
       <h1 className="text-2xl font-bold">Worlds</h1>
       <input
         type="file"


### PR DESCRIPTION
## Summary
- allow world markdown files to be dropped onto the Worlds page for import

## Testing
- `pre-commit run --files web/src/pages/WorldsPage.tsx`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ace73d3c008324881f106a09ce4988