### PR TITLE
Improve import error visibility

### DIFF
--- a/web/src/pages/WorldsPage.tsx
+++ b/web/src/pages/WorldsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
-const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000'
+const API_BASE = import.meta.env.VITE_API_URL ?? window.location.origin
 
 interface WorldSummary {
   id: number
@@ -46,7 +46,12 @@ export default function WorldsPage() {
       await importFile(file)
     } catch (err) {
       console.error(err)
-      alert('Import failed')
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg === 'Failed to fetch') {
+        alert(`Import failed: could not reach server at ${API_BASE}. Is it running?`)
+      } else {
+        alert(`Import failed: ${msg}`)
+      }
     } finally {
       e.target.value = ''
     }
@@ -58,7 +63,12 @@ export default function WorldsPage() {
     if (file) {
       importFile(file).catch((err) => {
         console.error(err)
-        alert('Import failed')
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg === 'Failed to fetch') {
+          alert(`Import failed: could not reach server at ${API_BASE}. Is it running?`)
+        } else {
+          alert(`Import failed: ${msg}`)
+        }
       })
     }
   }


### PR DESCRIPTION
## Summary
- use current origin as default API base so imports work when the backend runs on a different port
- surface clearer messages when world validation or import cannot reach the backend

## Testing
- `uv sync --extra dev`
- `pnpm -C web lint`
- `pnpm -C web typecheck`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8016992883249b8950b0ab255cd5