### PR TITLE
feat: display speaker tag in chat stream

### DIFF
--- a/web/src/components/ChatStream.tsx
+++ b/web/src/components/ChatStream.tsx
@@ -23,6 +23,9 @@ export default function ChatStream({ messages }: Props) {
               msg.role === 'player' ? 'text-blue-200' : 'text-gray-100'
             }`}
           >
+            <span className="font-semibold">
+              {msg.role === 'player' ? 'Player' : 'DM'}:
+            </span>{' '}
             {msg.content}
           </div>
         )}


### PR DESCRIPTION
## Summary
- show player/DM label before each chat message in the web UI

## Testing
- `pytest`
- `pre-commit run --files web/src/components/ChatStream.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b05a4433648324b5154751792f33b6