### PR TITLE
feat: make party members collapsible

### DIFF
--- a/web/src/components/PartyPanel.tsx
+++ b/web/src/components/PartyPanel.tsx
@@ -21,59 +21,47 @@ export default function PartyPanel({ party }: Props) {
     <div className="space-y-4 text-sm">
       <div>
         <h3 className="font-semibold">Player</h3>
-        <div className="mt-1 rounded border border-gray-700 p-2">
-          <div className="font-medium">{player.name}</div>
-          {player.stats && (
-            <div>
-              <div>HP: {player.stats.hp ?? 0}</div>
-              {player.stats.strength !== undefined && (
-                <div>STR: {player.stats.strength}</div>
-              )}
-              {player.stats.defense !== undefined && (
-                <div>DEF: {player.stats.defense}</div>
-              )}
-            </div>
-          )}
-          {player.background && <div>Background: {player.background}</div>}
-          {player.traits && <div>Traits: {player.traits}</div>}
-          {player.inventory && player.inventory.length > 0 && (
-            <div>Inventory: {player.inventory.join(', ')}</div>
-          )}
-          {player.status && <div>Status: {player.status}</div>}
-        </div>
+        <CharacterCard member={player} />
       </div>
       {others.length > 0 && (
         <div>
           <h3 className="font-semibold">Party</h3>
           <div className="space-y-2">
             {others.map((m) => (
-              <div
-                key={m.id}
-                className="rounded border border-gray-700 p-2"
-              >
-                <div className="font-medium">{m.name}</div>
-                {m.stats && (
-                  <div>
-                    <div>HP: {m.stats.hp ?? 0}</div>
-                    {m.stats.strength !== undefined && (
-                      <div>STR: {m.stats.strength}</div>
-                    )}
-                    {m.stats.defense !== undefined && (
-                      <div>DEF: {m.stats.defense}</div>
-                    )}
-                  </div>
-                )}
-                {m.background && <div>Background: {m.background}</div>}
-                {m.traits && <div>Traits: {m.traits}</div>}
-                {m.inventory && m.inventory.length > 0 && (
-                  <div>Inventory: {m.inventory.join(', ')}</div>
-                )}
-                {m.status && <div>Status: {m.status}</div>}
-              </div>
+              <CharacterCard key={m.id} member={m} />
             ))}
           </div>
         </div>
       )}
     </div>
+  )
+}
+
+function CharacterCard({ member }: { member: Character }) {
+  return (
+    <details className="rounded border border-gray-700 p-2">
+      <summary className="flex cursor-pointer justify-between">
+        <span className="font-medium">{member.name}</span>
+        {member.stats && (
+          <span>
+            HP: {member.stats.hp ?? 0}
+            {member.stats.strength !== undefined && (
+              <span className="ml-2">STR: {member.stats.strength}</span>
+            )}
+            {member.stats.defense !== undefined && (
+              <span className="ml-2">DEF: {member.stats.defense}</span>
+            )}
+          </span>
+        )}
+      </summary>
+      <div className="mt-2 space-y-1">
+        {member.background && <div>Background: {member.background}</div>}
+        {member.traits && <div>Traits: {member.traits}</div>}
+        {member.inventory && member.inventory.length > 0 && (
+          <div>Inventory: {member.inventory.join(', ')}</div>
+        )}
+        {member.status && <div>Status: {member.status}</div>}
+      </div>
+    </details>
   )
 }


### PR DESCRIPTION
## Summary
- collapse/expand party members to show only key stats at a glance
- reveal background, traits, inventory and status when expanded

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b060d43c1c8324afc27d674ecabc5d