### PR TITLE
feat: suggest options and allow custom action

### DIFF
--- a/server/app/engine_service.py
+++ b/server/app/engine_service.py
@@ -453,7 +453,9 @@ SYSTEM_INSTRUCTIONS = (
     "You are a fair and impartial DM. "
     "Describe the world and the results of actions, "
     "but never roll for the player. "
-    "Resolve companion and pet actions internally without requesting player rolls."
+    "Resolve companion and pet actions internally without requesting player rolls. "
+    "Whenever the player must choose a next step, present three logical, numbered "
+    "options and note that they may always suggest another action."
 )
 
 


### PR DESCRIPTION
## Summary
- prompt DM to suggest three numbered options while allowing custom actions

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0636cd9b083249c5c38d920b9520d