### PR TITLE
feat: add save and export endpoints

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -8,6 +8,7 @@ import logging
 from .engine_service import (
     DMResponse,
     add_companion,
+    autosave_game_state,
     create_game,
     export_game_state,
     get_game_state,
@@ -223,8 +224,17 @@ def update_game_endpoint(game_id: int, payload: GameUpdate) -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.get("/games/{game_id}/save")
-def save_game(game_id: int) -> Dict[str, Any]:
+@app.post("/games/{game_id}/save")
+def save_game(game_id: int) -> dict[str, str]:
+    try:
+        autosave_game_state(game_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"status": "ok"}
+
+
+@app.get("/games/{game_id}/export")
+def export_game(game_id: int) -> Dict[str, Any]:
     try:
         return export_game_state(game_id)
     except KeyError as exc:

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -23,6 +23,7 @@ def test_openapi_has_public_routes():
         "/games/{game_id}/companions",
         "/games/{game_id}/companions/{companion_id}",
         "/games/{game_id}/save",
+        "/games/{game_id}/export",
         "/games/import",
         "/health",
         "/health/llm",

--- a/tests/test_save_load_export.py
+++ b/tests/test_save_load_export.py
@@ -27,8 +27,15 @@ def test_save_export_import_flow(tmp_path, monkeypatch):
 
     client = TestClient(app)
 
-    # Save the game
-    resp = client.get("/games/1/save")
+    # Save the game to disk
+    engine_service.SAVE_DIR = tmp_path
+    resp = client.post("/games/1/save")
+    assert resp.status_code == 200
+    save_path = tmp_path / "game_1.json"
+    assert save_path.exists()
+
+    # Export the saved game
+    resp = client.get("/games/1/export")
     assert resp.status_code == 200
     saved = resp.json()
     assert saved["pending_roll"]["dc"] == 10

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -202,7 +202,24 @@ export interface paths {
             cookie?: never;
         };
         /** Save Game */
-        get: operations["save_game_games__game_id__save_get"];
+        get?: never;
+        put?: never;
+        post: operations["save_game_games__game_id__save_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/games/{game_id}/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Export Game */
+        get: operations["export_game_games__game_id__export_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -677,7 +694,40 @@ export interface operations {
             };
         };
     };
-    save_game_games__game_id__save_get: {
+    save_game_games__game_id__save_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                game_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_game_games__game_id__export_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/pages/PlayPage.tsx
+++ b/web/src/pages/PlayPage.tsx
@@ -20,7 +20,6 @@ export default function PlayPage() {
     instructions: string
   } | null>(null)
   const [worldTitle, setWorldTitle] = useState<string | null>(null)
-  const [worldId, setWorldId] = useState<string | null>(null)
   const [party, setParty] = useState<Character[]>([])
   const [showCreator, setShowCreator] = useState(false)
   const [statKeys, setStatKeys] = useState<string[]>([])
@@ -42,7 +41,6 @@ export default function PlayPage() {
         )
         setParty(game.party ?? [])
         setStatKeys(world.stats ?? [])
-        setWorldId(game.world_id)
       const map: Record<string, { label: string; instructions: string }> = {
         dnd5e: {
           label: 'D&D 5e',
@@ -134,7 +132,12 @@ export default function PlayPage() {
 
   async function saveGame() {
     if (!gameId) return
-    const resp = await fetch(`${API_BASE}/games/${gameId}/save`)
+    await fetch(`${API_BASE}/games/${gameId}/save`, { method: 'POST' })
+  }
+
+  async function exportGame() {
+    if (!gameId) return
+    const resp = await fetch(`${API_BASE}/games/${gameId}/export`)
     if (!resp.ok) return
     const data = await resp.json()
     const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -148,24 +151,10 @@ export default function PlayPage() {
     URL.revokeObjectURL(url)
   }
 
-  async function exportWorld() {
-    if (!worldId) return
-    const resp = await fetch(`${API_BASE}/worlds/${worldId}/export`)
-    if (!resp.ok) return
-    const text = await resp.text()
-    const blob = new Blob([text], { type: 'text/markdown' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `world-${worldId}-export.md`
-    a.click()
-    URL.revokeObjectURL(url)
-  }
-
   function handleCommand(cmd: string) {
     switch (cmd) {
       case 'save':
-        console.log('save game')
+        void saveGame()
         break
       case 'party':
         console.log('show party')
@@ -210,7 +199,7 @@ export default function PlayPage() {
             Save
           </button>
           <button
-            onClick={exportWorld}
+            onClick={exportGame}
             className="rounded bg-gray-700 px-2 py-1 text-white hover:bg-gray-800"
           >
             Export


### PR DESCRIPTION
## Summary
- add explicit save and export endpoints for games
- wire frontend save/export buttons to new endpoints
- extend tests and API types for save/export workflow

## Testing
- `pre-commit run --files server/app/main.py tests/test_api_surface.py tests/test_save_load_export.py web/src/api/types.ts web/src/pages/PlayPage.tsx`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b069103124832493cb2e6f6a2bf09e