### PR TITLE
Add AGENTS guidelines across project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+## General Guidelines
+- Run `pre-commit run --files <files>` before committing. For documentation-only changes, you may skip frontend hooks using `SKIP=frontend-lint,frontend-typecheck`.
+- For Python code changes, ensure `pytest` passes.
+- For frontend changes under `web/`, run `pnpm lint` and `pnpm typecheck`.
+- Keep commit messages clear and leave the worktree clean.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Documentation is written in Markdown.
+
+- Keep lines under 120 characters where practical.
+- Run `pre-commit run --files <files>` before committing.

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+Architectural Decision Records.
+
+- Files are named using `NNNN-title.md`.
+- Start with a level-1 heading matching the file name.
+- Run `pre-commit run --files <files>` before committing.

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Game engine core in Python.
+
+- Use type hints and docstrings.
+- Run `pre-commit run --files <files>` and relevant `pytest` tests.

--- a/engine/rules/AGENTS.md
+++ b/engine/rules/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+Rule modules for different systems.
+
+- Each file defines a `Ruleset` subclass named after the module.
+- Add tests in `tests/` when modifying rules.
+- Run `pre-commit run --files <files>` and `pytest`.

--- a/saves/AGENTS.md
+++ b/saves/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Sample save files.
+
+- Do not commit personal or sensitive game data.
+- Keep examples small and text-based.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+FastAPI backend.
+
+- Use type hints and docstrings.
+- Run `pre-commit run --files <files>` and `pytest` for backend tests.

--- a/server/app/AGENTS.md
+++ b/server/app/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Server application wiring.
+
+- Keep modules focused and readable.
+- Run `pre-commit run --files <files>` and `pytest`.

--- a/server/app/llm/AGENTS.md
+++ b/server/app/llm/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+LLM interface modules.
+
+- Abstract language models behind clear interfaces.
+- Run `pre-commit run --files <files>` and `pytest`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+pytest test suite.
+
+- Keep tests deterministic and isolated.
+- Run `pytest` after modifying tests or related code.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+Frontend built with React, TypeScript, and Vite.
+
+- Use `pnpm` for all scripts.
+- Run `pnpm lint` and `pnpm typecheck` before committing.
+- Formatting is handled by Prettier; run `pnpm format` as needed.

--- a/web/public/AGENTS.md
+++ b/web/public/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Static assets served by the frontend.
+
+- Optimize images and other media for the web.
+- Run `pre-commit run --files <files>` when adding assets.

--- a/web/src/AGENTS.md
+++ b/web/src/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Source code for the frontend.
+
+- Use TypeScript and React conventions.
+- Run `pnpm lint` and `pnpm typecheck` before committing.

--- a/web/src/api/AGENTS.md
+++ b/web/src/api/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+API helpers for the frontend.
+
+- Keep functions small and typed.
+- Run `pnpm lint` and `pnpm typecheck`.

--- a/web/src/assets/AGENTS.md
+++ b/web/src/assets/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Frontend-specific assets.
+
+- Prefer vector or small files.
+- Run `pre-commit run --files <files>` when adding assets.

--- a/web/src/components/AGENTS.md
+++ b/web/src/components/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Reusable React components.
+
+- Keep components small and typed.
+- Run `pnpm lint` and `pnpm typecheck`.

--- a/web/src/pages/AGENTS.md
+++ b/web/src/pages/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Page-level components.
+
+- Organize routes by page name.
+- Run `pnpm lint` and `pnpm typecheck`.

--- a/worlds/AGENTS.md
+++ b/worlds/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Markdown-based world definitions.
+
+- Keep lore concise and consistent.
+- Run `pre-commit run --files <files>` when updating worlds.


### PR DESCRIPTION
## Summary
- add AGENTS.md with general repo guidelines
- document contribution rules for docs, engine, server, tests, web, worlds, and other subfolders

## Testing
- `pre-commit run --files AGENTS.md docs/AGENTS.md docs/adr/AGENTS.md engine/AGENTS.md engine/rules/AGENTS.md saves/AGENTS.md server/AGENTS.md server/app/AGENTS.md server/app/llm/AGENTS.md tests/AGENTS.md web/AGENTS.md web/public/AGENTS.md web/src/AGENTS.md web/src/api/AGENTS.md web/src/assets/AGENTS.md web/src/components/AGENTS.md web/src/pages/AGENTS.md worlds/AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_68b13bee99d4832496723ac4c65078c0