### PR TITLE
Fix markdown rendering and component cleanup

### DIFF
--- a/web/src/components/ChatStream.tsx
+++ b/web/src/components/ChatStream.tsx
@@ -20,14 +20,15 @@ export default function ChatStream({ messages }: Props) {
         followOutput="smooth"
         className="p-4"
         itemContent={(_, msg) => (
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
+          <div
             className={`mb-2 whitespace-pre-wrap ${
               msg.role === 'player' ? 'text-blue-200' : 'text-gray-100'
             }`}
           >
-            {`**${msg.role === 'player' ? 'Player' : 'DM'}:** ${msg.content}`}
-          </ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {`**${msg.role === 'player' ? 'Player' : 'DM'}:** ${msg.content}`}
+            </ReactMarkdown>
+          </div>
         )}
       />
     </div>

--- a/web/src/components/PartyPanel.tsx
+++ b/web/src/components/PartyPanel.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export interface Character {
   id: number | string
   name: string


### PR DESCRIPTION
## Summary
- wrap ChatStream message markup and remove invalid `className` on ReactMarkdown
- drop unused React import from PartyPanel component

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pre-commit run --files web/src/components/ChatStream.tsx web/src/components/PartyPanel.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b148be1868832482f99594ca74a798