### PR TITLE
Add save selection and loading in web UI

### DIFF
--- a/server/app/engine_service.py
+++ b/server/app/engine_service.py
@@ -412,6 +412,20 @@ def load_autosave(game_id: int) -> None:
     _GAME_STATES[game_id] = _deserialize_game_state(data)
 
 
+def list_saved_games() -> list[dict[str, int]]:
+    """Return identifiers for saved games on disk."""
+    games: list[dict[str, int]] = []
+    for path in SAVE_DIR.glob("game_*.json"):
+        try:
+            game_id = int(path.stem.split("_")[1])
+            data = json.loads(path.read_text(encoding="utf-8"))
+            world_id = int(data["world_id"])
+        except (IndexError, KeyError, ValueError, json.JSONDecodeError):
+            continue
+        games.append({"id": game_id, "world_id": world_id})
+    return games
+
+
 def _deserialize_game_state(data: Dict[str, Any]) -> GameState:
     memory = [MemoryItem(**m) for m in data.get("memory", [])]
     return GameState(

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -11,6 +11,7 @@ from .engine_service import (
     autosave_game_state,
     create_game,
     export_game_state,
+    list_saved_games,
     get_game_state,
     get_world,
     import_game_state,
@@ -119,6 +120,12 @@ class PlayerRoll(BaseModel):
 
 class GameCreate(BaseModel):
     world_id: int
+
+
+@app.get("/games")
+def list_games_endpoint() -> list[dict[str, int]]:
+    """List saved games found on disk."""
+    return list_saved_games()
 
 
 @app.post("/games")

--- a/tests/test_save_load_export.py
+++ b/tests/test_save_load_export.py
@@ -34,6 +34,11 @@ def test_save_export_import_flow(tmp_path, monkeypatch):
     save_path = tmp_path / "game_1.json"
     assert save_path.exists()
 
+    # List saved games
+    resp_list = client.get("/games")
+    assert resp_list.status_code == 200
+    assert {"id": 1, "world_id": 1} in resp_list.json()
+
     # Export the saved game
     resp = client.get("/games/1/export")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- list saved games from the backend
- allow loading autosaves from Play and Worlds pages
- test saved game listing

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `uvx pre-commit run --files server/app/engine_service.py server/app/main.py web/src/pages/PlayPage.tsx web/src/pages/WorldsPage.tsx tests/test_save_load_export.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b14bdf25448324b1066508c6f3897e