### PR TITLE
Support dynamic world discovery with refresh button

### DIFF
--- a/tests/test_worlds_refresh.py
+++ b/tests/test_worlds_refresh.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+from server.app import engine_service
+from server.app.main import app
+
+
+def test_world_listing_detects_new_files() -> None:
+    client = TestClient(app)
+    initial = client.get("/worlds").json()
+    path = engine_service.WORLD_DIR / "temp_world.md"
+    content = (
+        "---\n"
+        "id: temp\n"
+        "title: Temp World\n"
+        "ruleset: custom_d6\n"
+        "end_goal: fun\n"
+        "---\n\n"
+        "## Lore\n"
+        "Temporary world\n"
+    )
+    path.write_text(content, encoding="utf-8")
+    try:
+        updated = client.get("/worlds").json()
+        assert len(updated) == len(initial) + 1
+    finally:
+        if path.exists():
+            path.unlink()
+        wid = engine_service._WORLD_FILES.pop(path, None)
+        if wid is not None:
+            engine_service._WORLDS.pop(wid, None)

--- a/web/src/pages/WorldsPage.tsx
+++ b/web/src/pages/WorldsPage.tsx
@@ -20,24 +20,33 @@ export default function WorldsPage() {
   const [saves, setSaves] = useState<Record<number, number[]>>({})
 
   async function fetchWorlds() {
-    fetch(`${API_BASE}/worlds`)
-      .then((r) => r.json())
-      .then((data) => setWorlds(data as WorldSummary[]))
-      .catch(() => setWorlds([]))
+    try {
+      const res = await fetch(`${API_BASE}/worlds`)
+      const data = (await res.json()) as WorldSummary[]
+      setWorlds(data)
+    } catch {
+      setWorlds([])
+    }
   }
 
   async function fetchSaves() {
-    fetch(`${API_BASE}/games`)
-      .then((r) => r.json())
-      .then((data: SavedGame[]) => {
-        const grouped: Record<number, number[]> = {}
-        for (const g of data) {
-          grouped[g.world_id] = grouped[g.world_id] || []
-          grouped[g.world_id].push(g.id)
-        }
-        setSaves(grouped)
-      })
-      .catch(() => setSaves({}))
+    try {
+      const res = await fetch(`${API_BASE}/games`)
+      const data = (await res.json()) as SavedGame[]
+      const grouped: Record<number, number[]> = {}
+      for (const g of data) {
+        grouped[g.world_id] = grouped[g.world_id] || []
+        grouped[g.world_id].push(g.id)
+      }
+      setSaves(grouped)
+    } catch {
+      setSaves({})
+    }
+  }
+
+  async function handleRefresh() {
+    await fetchWorlds()
+    await fetchSaves()
   }
 
   useEffect(() => {
@@ -123,6 +132,9 @@ export default function WorldsPage() {
         onChange={handleUpload}
         className="w-full max-w-md"
       />
+      <button onClick={handleRefresh} className="text-blue-500 underline">
+        Refresh
+      </button>
       <ul className="w-full max-w-md flex-1 overflow-auto">
         {worlds.map((w) => (
           <li key={w.id} className="border-b border-gray-700 p-2">


### PR DESCRIPTION
## Summary
- Load world definitions from filesystem on demand
- Add refresh button to browse worlds page to reload worlds and saves
- Test dynamic discovery of new world files

## Testing
- `pre-commit run --files server/app/engine_service.py web/src/pages/WorldsPage.tsx tests/test_worlds_refresh.py`
- `pnpm lint`
- `pnpm typecheck`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b14f5600ac83248b024677f515d881