### PR TITLE
Ensure DM waits for player dice rolls

### DIFF
--- a/engine/mechanics.py
+++ b/engine/mechanics.py
@@ -17,8 +17,8 @@ class RollRequest(BaseModel):
 
 
 _ROLL_RE = re.compile(
-    r"roll\s+(?:a|an)?\s*d(?P<die>\d+)\s+for\s+"
-    r"(?P<skill>[^()]+)"
+    r"roll\s+(?:a|an)?\s*(?P<count>\d*)d(?P<die>\d+)"
+    r"(?:\s+for\s+(?P<skill>[^()]+)|\s+(?P<damage>damage))?"
     r"(?:\s*\(dc\s*(?P<dc>\d+)\))?",
     re.IGNORECASE,
 )
@@ -43,7 +43,13 @@ def detect_roll_request(dm_text: str) -> Optional[RollRequest]:
         return None
 
     sides = int(match.group("die"))
-    skill = match.group("skill").strip().title()
+    skill_raw = match.group("skill")
+    if skill_raw:
+        skill = skill_raw.strip().title()
+    elif match.group("damage"):
+        skill = "Damage"
+    else:
+        skill = "Check"
     dc_str = match.group("dc")
     dc = int(dc_str) if dc_str is not None else None
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -20,3 +20,12 @@ def test_detects_roll_request():
 def test_no_roll_request():
     text = "The dragon snarls and watches you carefully."
     assert mechanics.detect_roll_request(text) is None
+
+
+def test_detects_damage_roll_request():
+    text = "Roll 1d8 damage"
+    req = mechanics.detect_roll_request(text)
+    assert req is not None
+    assert req.sides == 8
+    assert req.skill == "Damage"
+    assert req.dc is None

--- a/tests/test_player_roll_submission.py
+++ b/tests/test_player_roll_submission.py
@@ -15,7 +15,7 @@ from engine.world_loader import World, SectionEntry
 
 def test_player_roll_submission(monkeypatch):
     responses = [
-        "You look around. Roll a d20 for Perception (DC 10).",
+        "You look around. Roll a d20 for Perception (DC 10). You rolled 5 and fail.",
         "You spot a hidden door.",
     ]
 
@@ -38,8 +38,9 @@ def test_player_roll_submission(monkeypatch):
         world_id=1, current_location=0
     )
 
-    asyncio.run(engine_service.run_turn(1, "look"))
+    resp = asyncio.run(engine_service.run_turn(1, "look"))
 
+    assert resp.message == "You look around. Roll a d20 for Perception (DC 10)."
     pending = engine_service._GAME_STATES[1].pending_roll
     assert pending is not None
 


### PR DESCRIPTION
## Summary
- prevent DM from auto-rolling for players by trimming narration after roll requests
- broaden roll detection to cover damage rolls and unnamed checks
- clarify system instructions to always await player rolls, including damage rolls

## Testing
- `pre-commit run --files engine/mechanics.py server/app/engine_service.py tests/test_mechanics.py tests/test_player_roll_submission.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1568677508324b708faef5e8d06e2