### PR TITLE
Allow updating additional world sections

### DIFF
--- a/server/app/engine_service.py
+++ b/server/app/engine_service.py
@@ -324,8 +324,9 @@ def update_world(world_id: int, updates: Dict[str, Any]) -> None:
     if world is None:
         raise KeyError(f"Unknown world id: {world_id}")
 
-    if "npcs" in updates:
-        world.npcs = [SectionEntry(**n) for n in updates.pop("npcs")]
+    for section in ("locations", "npcs", "factions", "items"):
+        if section in updates:
+            setattr(world, section, [SectionEntry(**n) for n in updates.pop(section)])
     for key, value in updates.items():
         setattr(world, key, value)
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -98,7 +98,10 @@ class WorldUpdate(BaseModel):
     title: str | None = None
     ruleset: str | None = None
     lore: str | None = None
+    locations: list[Dict[str, str]] | None = None
     npcs: list[Dict[str, str]] | None = None
+    factions: list[Dict[str, str]] | None = None
+    items: list[Dict[str, str]] | None = None
     rules_notes: str | None = None
     stats: list[str] | None = None
 

--- a/tests/test_game_update.py
+++ b/tests/test_game_update.py
@@ -26,7 +26,15 @@ def test_update_game_state_endpoint():
     game_id = engine_service.create_game(1)
 
     client = TestClient(app)
-    resp_w = client.patch("/worlds/1", json={"lore": "new"})
+    resp_w = client.patch(
+        "/worlds/1",
+        json={
+            "lore": "new",
+            "locations": [{"name": "Forest", "description": ""}],
+            "factions": [{"name": "Guild", "description": ""}],
+            "items": [{"name": "Sword", "description": ""}],
+        },
+    )
     assert resp_w.status_code == 200
 
     payload = {
@@ -39,4 +47,8 @@ def test_update_game_state_endpoint():
     state = engine_service.get_game_state(game_id)
     assert state["party"][0]["name"] == "Hero"
     assert state["memory"][0]["content"] == "saved town"
-    assert engine_service.get_world(1).lore == "new"
+    world = engine_service.get_world(1)
+    assert world.lore == "new"
+    assert world.locations[0].name == "Forest"
+    assert world.factions[0].name == "Guild"
+    assert world.items[0].name == "Sword"


### PR DESCRIPTION
## Summary
- support updating locations, factions, and items in world patches
- cover new world sections in engine service
- test world updates with additional sections

## Testing
- `pre-commit run --files server/app/main.py server/app/engine_service.py tests/test_game_update.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1911aaf4c8324b6f151ebfde10a95