### PR TITLE
Include party inventory in DM prompt

### DIFF
--- a/engine/context.py
+++ b/engine/context.py
@@ -39,15 +39,18 @@ def build_prompt(world: World, state: object, k: int = 5) -> str:
     npcs = _format_entries(world.npcs)
     parts.append(f"NPCs here: {npcs}")
 
-    # Party roster with personas
-    roster = []
+    # Party roster with personas and inventory
+    roster: list[str] = []
     for member in getattr(state, "party", []):
         name = member.get("name", "?")
         persona = member.get("persona")
+        inventory = member.get("inventory") or []
+        desc = name
         if persona:
-            roster.append(f"{name}: {persona}")
-        else:
-            roster.append(name)
+            desc += f": {persona}"
+        if inventory:
+            desc += f" (inventory: {', '.join(inventory)})"
+        roster.append(desc)
     parts.append(f"Party: {', '.join(roster) or 'none'}")
 
     # Memories

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -50,3 +50,28 @@ def test_party_limits_and_prompt_personas() -> None:
     world = _make_world()
     prompt = context.build_prompt(world, state)
     assert "C0: P0" in prompt and "Pet0: PP0" in prompt
+
+
+def test_inventory_in_prompt() -> None:
+    """Inventory items should be reflected in the DM prompt."""
+
+    state = models.GameState(
+        world_id=1,
+        current_location=0,
+        party=[
+            {
+                "id": 1,
+                "name": "Hero",
+                "persona": "Brave adventurer",
+                "inventory": ["Potion", "Sword"],
+            }
+        ],
+        flags={},
+        timeline=[],
+        memory=[],
+        pending_roll=None,
+    )
+
+    world = _make_world()
+    prompt = context.build_prompt(world, state)
+    assert "inventory: Potion, Sword" in prompt


### PR DESCRIPTION
## Summary
- include each party member's inventory when building the DM prompt
- add regression test for inventory presence in prompt

## Testing
- `pre-commit run --files engine/context.py tests/test_party.py`
- `pytest tests/test_party.py tests/test_state_updates.py`


------
https://chatgpt.com/codex/tasks/task_e_68b414de12a083249da542193403cf0d